### PR TITLE
Add unify_values option to normalization (and update tarpaulin to v0.30.0)

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-tarpaulin
-          version: 0.27.3
+          version: 0.30.0
           use-tool-cache: true
       - name: Checkout
         uses: actions/checkout@v4

--- a/sql-insight-cli/src/main.rs
+++ b/sql-insight-cli/src/main.rs
@@ -44,6 +44,9 @@ struct NormalizeCommandOptions {
     /// Unify IN lists to a single form when all elements are literal values. For example, `IN (1, 2, 3)` becomes `IN (...)`.
     #[clap(long)]
     unify_in_list: bool,
+    /// Unify VALUES lists to a single form when all elements are literal values. For example, `VALUES (1, 2, 3), (4, 5, 6)` becomes `VALUES (...)`.
+    #[clap(long)]
+    unify_values: bool,
 }
 
 enum ProcessType {
@@ -172,8 +175,11 @@ impl Commands {
         match self {
             Commands::Format(opts) => Box::new(FormatExecutor::new(sql, opts.dialect.clone())),
             Commands::Normalize(opts) => Box::new(
-                NormalizeExecutor::new(sql, opts.common_options.dialect.clone())
-                    .with_options(NormalizerOptions::new().with_unify_in_list(opts.unify_in_list)),
+                NormalizeExecutor::new(sql, opts.common_options.dialect.clone()).with_options(
+                    NormalizerOptions::new()
+                        .with_unify_in_list(opts.unify_in_list)
+                        .with_unify_values(opts.unify_values),
+                ),
             ),
             Commands::ExtractCrud(opts) => {
                 Box::new(CrudTableExtractExecutor::new(sql, opts.dialect.clone()))

--- a/sql-insight-cli/tests/integration.rs
+++ b/sql-insight-cli/tests/integration.rs
@@ -85,6 +85,35 @@ mod integration {
         }
 
         #[test]
+        fn test_normalize_with_unify_values_option() {
+            sql_insight_cmd()
+                .arg("normalize")
+                .arg("--unify-values")
+                .arg("select * from t1 where a = 1 and b in (2, 3); insert into t2 (a) values (4), (5), (6);")
+                .assert()
+                .success()
+                .stdout(
+                    "SELECT * FROM t1 WHERE a = ? AND b IN (?, ?)\nINSERT INTO t2 (a) VALUES (...)\n",
+                )
+                .stderr("");
+        }
+
+        #[test]
+        fn test_normalize_with_all_options() {
+            sql_insight_cmd()
+                .arg("normalize")
+                .arg("--unify-in-list")
+                .arg("--unify-values")
+                .arg("select * from t1 where a = 1 and b in (2, 3); insert into t2 (a) values (4), (5), (6);")
+                .assert()
+                .success()
+                .stdout(
+                    "SELECT * FROM t1 WHERE a = ? AND b IN (...)\nINSERT INTO t2 (a) VALUES (...)\n",
+                )
+                .stderr("");
+        }
+
+        #[test]
         fn test_normalize_with_dialect() {
             sql_insight_cmd()
                 .arg("normalize")

--- a/sql-insight/tests/integration.rs
+++ b/sql-insight/tests/integration.rs
@@ -39,17 +39,22 @@ mod integration {
 
         #[test]
         fn test_normalize_with_options() {
-            let sql = "SELECT a FROM t1 WHERE b = 1 AND c in (2, 3, 4)";
+            let sql = "SELECT a FROM t1 WHERE b = 1 AND c in (2, 3, 4); INSERT INTO t2 (a, b, c) VALUES (1, 2, 3), (4, 5, 6)";
             for dialect in all_dialects() {
                 let result = sql_insight::normalize_with_options(
                     dialect.as_ref(),
                     sql,
-                    NormalizerOptions::new().with_unify_in_list(true),
+                    NormalizerOptions::new()
+                        .with_unify_in_list(true)
+                        .with_unify_values(true),
                 )
                 .unwrap();
                 assert_eq!(
                     result,
-                    ["SELECT a FROM t1 WHERE b = ? AND c IN (...)"],
+                    [
+                        "SELECT a FROM t1 WHERE b = ? AND c IN (...)",
+                        "INSERT INTO t2 (a, b, c) VALUES (...)"
+                    ],
                     "Failed for dialect: {dialect:?}"
                 )
             }


### PR DESCRIPTION
Add unify_values option to normalization.
For example, `VALUES (1, 2, 3), (4, 5, 6)` becomes `VALUES (...)`.
This option is derived from pt-fingerprint behaviour.