### PR TITLE
Normalize column lists, nested `IN` expressions, and unary operators

### DIFF
--- a/sql-insight/src/normalizer.rs
+++ b/sql-insight/src/normalizer.rs
@@ -152,10 +152,7 @@ impl VisitorMut for Normalizer {
     fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
         match expr {
             Expr::InList { list, .. } if self.options.unify_in_list => {
-                if list
-                    .iter()
-                    .all(|expr| Self::contains_only_tuples_of_values(expr))
-                {
+                if list.iter().all(Self::contains_only_tuples_of_values) {
                     *list = vec![Expr::Value(Value::Placeholder("...".into()))];
                 }
             }
@@ -193,9 +190,7 @@ impl Normalizer {
     fn contains_only_tuples_of_values(expr: &Expr) -> bool {
         match expr {
             Expr::Value(_) => true,
-            Expr::Tuple(v) => v
-                .iter()
-                .all(|child| Self::contains_only_tuples_of_values(child)),
+            Expr::Tuple(v) => v.iter().all(Self::contains_only_tuples_of_values),
             _ => false,
         }
     }

--- a/sql-insight/src/normalizer.rs
+++ b/sql-insight/src/normalizer.rs
@@ -109,10 +109,19 @@ impl VisitorMut for Normalizer {
         ControlFlow::Continue(())
     }
 
-    fn post_visit_statement(&mut self, stmt: &mut sqlparser::ast::Statement) -> ControlFlow<Self::Break> {
+    fn post_visit_statement(
+        &mut self,
+        stmt: &mut sqlparser::ast::Statement,
+    ) -> ControlFlow<Self::Break> {
         if self.options.alphabetize_insert_columns {
-            if let Statement::Insert { columns, after_columns, source, .. } = stmt {
-                if let Some(Query{ body, .. }) = source.as_deref() {
+            if let Statement::Insert {
+                columns,
+                after_columns,
+                source,
+                ..
+            } = stmt
+            {
+                if let Some(Query { body, .. }) = source.as_deref() {
                     if let SetExpr::Values(v) = body.deref() {
                         if v.rows == vec![vec![Expr::Value(Value::Placeholder("...".into()))]] {
                             if columns.len() > 1 {
@@ -143,7 +152,10 @@ impl VisitorMut for Normalizer {
     fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
         match expr {
             Expr::InList { list, .. } if self.options.unify_in_list => {
-                if list.iter().all(|expr| Self::contains_only_tuples_of_values(expr)) {
+                if list
+                    .iter()
+                    .all(|expr| Self::contains_only_tuples_of_values(expr))
+                {
                     *list = vec![Expr::Value(Value::Placeholder("...".into()))];
                 }
             }
@@ -181,7 +193,9 @@ impl Normalizer {
     fn contains_only_tuples_of_values(expr: &Expr) -> bool {
         match expr {
             Expr::Value(_) => true,
-            Expr::Tuple(v) => v.iter().all(|child| Self::contains_only_tuples_of_values(child)),
+            Expr::Tuple(v) => v
+                .iter()
+                .all(|child| Self::contains_only_tuples_of_values(child)),
             _ => false,
         }
     }
@@ -328,7 +342,9 @@ mod tests {
             sql,
             expected,
             all_dialects(),
-            NormalizerOptions::new().with_unify_values(true).with_alphabetize_insert_columns(true),
+            NormalizerOptions::new()
+                .with_unify_values(true)
+                .with_alphabetize_insert_columns(true),
         );
     }
 
@@ -340,7 +356,9 @@ mod tests {
             sql,
             expected,
             all_dialects(),
-            NormalizerOptions::new().with_unify_values(true).with_alphabetize_insert_columns(true),
+            NormalizerOptions::new()
+                .with_unify_values(true)
+                .with_alphabetize_insert_columns(true),
         );
     }
 }


### PR DESCRIPTION
This PR extends two normalization behaviors and adds one new one, to match the normalization behavior in PlanetScale [Query Insights](https://planetscale.com/docs/concepts/query-insights).

First, unary operators followed by a constant are normalized along with the constant.  For example, the expression `a = -9` now normalizes as `a = ?` rather than as `a = -?`.

Second, `IN` lists are unified if they contain tuples, or nested tuples, of constant values.  For example, the query `SELECT * FROM t1 WHERE (a, b) IN ((1, 'x'), (2, 'y'))` now normalizes to `SELECT * FROM t1 WHERE (a, b) IN (...)`.

Finally, I've added a new normalizer option: `alphabetize_insert_columns`.  It causes the normalizer to alphabetize column lists on `INSERT` statements, so long as what's being inserted is a `VALUES` list that will be unified.  There is at least one ORM that randomizes the order of columns in `INSERT` statements, and we need to undo that to avoid getting `O(n!)` different normalized patterns for equivalent `INSERT` statements.