### PR TITLE
Upgrade sqlparser dependency to 0.56.0

### DIFF
--- a/sql-insight-cli/tests/integration.rs
+++ b/sql-insight-cli/tests/integration.rs
@@ -319,7 +319,7 @@ mod integration {
             write_to_stdin(stdin, "SELECT *  \n FROM t1 WHERE;\n").await?;
             let invalid_query_result = read_from_stderr(&mut stderr_reader).await?;
             assert!(
-                invalid_query_result.contains("Error: sql parser error: Expected an expression:"),
+                invalid_query_result.contains("Error: sql parser error: Expected: an expression,"),
                 "Invalid query result not as expected: {invalid_query_result:?}"
             );
 

--- a/sql-insight/Cargo.toml
+++ b/sql-insight/Cargo.toml
@@ -22,7 +22,7 @@ name = "sql_insight"
 path = "src/lib.rs"
 
 [dependencies]
-sqlparser = { version = "0.43.1", features = ["visitor"] }
+sqlparser = { version = "0.56.0", features = ["visitor"] }
 thiserror = "1.0.56"
 
 

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -210,7 +210,7 @@ mod tests {
     ) {
         for dialect in dialects {
             let result = CrudTableExtractor::extract(dialect.as_ref(), sql)
-                .expect(&format!("parse failed for dialect: {dialect:?}"));
+                .unwrap_or_else(|_| panic!("parse failed for dialect: {dialect:?}"));
             assert_eq!(result, expected, "Failed for dialect: {dialect:?}")
         }
     }

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -209,7 +209,7 @@ mod tests {
         dialects: Vec<Box<dyn Dialect>>,
     ) {
         for dialect in dialects {
-            let result = CrudTableExtractor::extract(dialect.as_ref(), sql).unwrap();
+            let result = CrudTableExtractor::extract(dialect.as_ref(), sql).expect(&format!("parse failed for dialect: {dialect:?}"));
             assert_eq!(result, expected, "Failed for dialect: {dialect:?}")
         }
     }

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -209,7 +209,8 @@ mod tests {
         dialects: Vec<Box<dyn Dialect>>,
     ) {
         for dialect in dialects {
-            let result = CrudTableExtractor::extract(dialect.as_ref(), sql).expect(&format!("parse failed for dialect: {dialect:?}"));
+            let result = CrudTableExtractor::extract(dialect.as_ref(), sql)
+                .expect(&format!("parse failed for dialect: {dialect:?}"));
             assert_eq!(result, expected, "Failed for dialect: {dialect:?}")
         }
     }
@@ -419,7 +420,11 @@ mod tests {
                 ],
             })];
             // BigQuery and Generic do not support DELETE ... FROM
-            assert_crud_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
+            assert_crud_table_extraction(
+                sql,
+                expected,
+                all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]),
+            );
         }
 
         #[test]
@@ -465,7 +470,11 @@ mod tests {
                 ],
             })];
             // BigQuery and Generic do not support DELETE ... FROM
-            assert_crud_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
+            assert_crud_table_extraction(
+                sql,
+                expected,
+                all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]),
+            );
         }
 
         #[test]

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -322,6 +322,8 @@ mod tests {
     }
 
     mod delete_statement {
+        use crate::test_utils::all_dialects_except;
+
         use super::*;
 
         #[test]
@@ -416,7 +418,8 @@ mod tests {
                     },
                 ],
             })];
-            assert_crud_table_extraction(sql, expected, all_dialects());
+            // BigQuery and Generic do not support DELETE ... FROM
+            assert_crud_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
         }
 
         #[test]
@@ -461,7 +464,8 @@ mod tests {
                     },
                 ],
             })];
-            assert_crud_table_extraction(sql, expected, all_dialects());
+            // BigQuery and Generic do not support DELETE ... FROM
+            assert_crud_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
         }
 
         #[test]

--- a/sql-insight/src/extractor/table_extractor.rs
+++ b/sql-insight/src/extractor/table_extractor.rs
@@ -251,7 +251,7 @@ mod tests {
         dialects: Vec<Box<dyn Dialect>>,
     ) {
         for dialect in dialects {
-            let result = TableExtractor::extract(dialect.as_ref(), sql).unwrap();
+            let result = TableExtractor::extract(dialect.as_ref(), sql).expect(&format!("parse failed for dialect: {dialect:?}"));
             assert_eq!(result, expected, "Failed for dialect: {dialect:?}")
         }
     }

--- a/sql-insight/src/extractor/table_extractor.rs
+++ b/sql-insight/src/extractor/table_extractor.rs
@@ -7,7 +7,7 @@ use std::ops::ControlFlow;
 
 use crate::error::Error;
 use crate::helper;
-use sqlparser::ast::{Ident, ObjectName, Statement, TableFactor, TableWithJoins, Visit, Visitor};
+use sqlparser::ast::{Delete, Ident, Insert, ObjectName, Statement, TableFactor, TableObject, TableWithJoins, Visit, Visitor};
 use sqlparser::dialect::Dialect;
 use sqlparser::parser::Parser;
 
@@ -49,6 +49,35 @@ impl TableReference {
     pub fn has_qualifiers(&self) -> bool {
         self.catalog.is_some() || self.schema.is_some()
     }
+    pub fn try_from_name_and_alias(name: &ObjectName, alias: &Option<Ident>) -> Result<Self, Error> {
+        match name.0.len() {
+            0 => unreachable!("Parser should not allow empty identifiers"),
+            1 => Ok(TableReference {
+                catalog: None,
+                schema: None,
+                name: name.0[0].as_ident().unwrap().clone(),
+                alias: alias.clone(),
+            }),
+            2 => Ok(TableReference {
+                catalog: None,
+                schema: Some(name.0[0].as_ident().unwrap().clone()),
+                name: name.0[1].as_ident().unwrap().clone(),
+                alias: alias.clone(),
+            }),
+            3 => Ok(TableReference {
+                catalog: Some(name.0[0].as_ident().unwrap().clone()),
+                schema: Some(name.0[1].as_ident().unwrap().clone()),
+                name: name.0[2].as_ident().unwrap().clone(),
+                alias: alias.clone(),
+            }),
+            _ => Err(Error::AnalysisError(
+                "Too many identifiers provided".to_string(),
+            )),
+        }
+    }
+    pub fn try_from_name(name: &ObjectName) -> Result<Self, Error> {
+        Self::try_from_name_and_alias(name, &None)
+    }
 }
 
 impl fmt::Display for TableReference {
@@ -70,35 +99,24 @@ impl fmt::Display for TableReference {
     }
 }
 
+impl TryFrom<&Insert> for TableReference {
+    type Error = Error;
+
+    fn try_from(value: &Insert) -> Result<Self, Self::Error> {
+        let name = match &value.table {
+            TableObject::TableName(object_name) => object_name,
+            TableObject::TableFunction(function) => &function.name,
+        };
+        Self::try_from_name_and_alias(name, &value.table_alias)
+    }
+}
+
 impl TryFrom<&TableFactor> for TableReference {
     type Error = Error;
 
     fn try_from(table: &TableFactor) -> Result<Self, Self::Error> {
         match table {
-            TableFactor::Table { name, alias, .. } => match name.0.len() {
-                0 => unreachable!("Parser should not allow empty identifiers"),
-                1 => Ok(TableReference {
-                    catalog: None,
-                    schema: None,
-                    name: name.0[0].clone(),
-                    alias: alias.as_ref().map(|a| a.name.clone()),
-                }),
-                2 => Ok(TableReference {
-                    catalog: None,
-                    schema: Some(name.0[0].clone()),
-                    name: name.0[1].clone(),
-                    alias: alias.as_ref().map(|a| a.name.clone()),
-                }),
-                3 => Ok(TableReference {
-                    catalog: Some(name.0[0].clone()),
-                    schema: Some(name.0[1].clone()),
-                    name: name.0[2].clone(),
-                    alias: alias.as_ref().map(|a| a.name.clone()),
-                }),
-                _ => Err(Error::AnalysisError(
-                    "Too many identifiers provided".to_string(),
-                )),
-            },
+            TableFactor::Table { name, alias, .. } => Self::try_from_name_and_alias(name, &alias.as_ref().map(|a| a.name.clone())),
             _ => unreachable!("TableFactor::Table expected"),
         }
     }
@@ -108,30 +126,7 @@ impl TryFrom<&ObjectName> for TableReference {
     type Error = Error;
 
     fn try_from(obj_name: &ObjectName) -> Result<Self, Self::Error> {
-        match obj_name.0.len() {
-            0 => unreachable!("Parser should not allow empty identifiers"),
-            1 => Ok(TableReference {
-                catalog: None,
-                schema: None,
-                name: obj_name.0[0].clone(),
-                alias: None,
-            }),
-            2 => Ok(TableReference {
-                catalog: None,
-                schema: Some(obj_name.0[0].clone()),
-                name: obj_name.0[1].clone(),
-                alias: None,
-            }),
-            3 => Ok(TableReference {
-                catalog: Some(obj_name.0[0].clone()),
-                schema: Some(obj_name.0[1].clone()),
-                name: obj_name.0[2].clone(),
-                alias: None,
-            }),
-            _ => Err(Error::AnalysisError(
-                "Too many identifiers provided".to_string(),
-            )),
-        }
+        Self::try_from_name(obj_name)
     }
 }
 
@@ -196,7 +191,7 @@ impl Visitor for TableExtractor {
     }
 
     fn pre_visit_statement(&mut self, statement: &Statement) -> ControlFlow<Self::Break> {
-        if let Statement::Delete { tables, .. } = statement {
+        if let Statement::Delete(Delete { tables, .. }) = statement {
             // tables of delete statement are not visited by `pre_visit_table_factor` nor `pre_visit_relation`.
             for table in tables {
                 match TableReference::try_from(table) {

--- a/sql-insight/src/extractor/table_extractor.rs
+++ b/sql-insight/src/extractor/table_extractor.rs
@@ -260,7 +260,7 @@ mod tests {
     ) {
         for dialect in dialects {
             let result = TableExtractor::extract(dialect.as_ref(), sql)
-                .expect(&format!("parse failed for dialect: {dialect:?}"));
+                .unwrap_or_else(|_| panic!("parse failed for dialect: {dialect:?}"));
             assert_eq!(result, expected, "Failed for dialect: {dialect:?}")
         }
     }

--- a/sql-insight/src/extractor/table_extractor.rs
+++ b/sql-insight/src/extractor/table_extractor.rs
@@ -7,7 +7,10 @@ use std::ops::ControlFlow;
 
 use crate::error::Error;
 use crate::helper;
-use sqlparser::ast::{Delete, Ident, Insert, ObjectName, Statement, TableFactor, TableObject, TableWithJoins, Visit, Visitor};
+use sqlparser::ast::{
+    Delete, Ident, Insert, ObjectName, Statement, TableFactor, TableObject, TableWithJoins, Visit,
+    Visitor,
+};
 use sqlparser::dialect::Dialect;
 use sqlparser::parser::Parser;
 
@@ -49,7 +52,10 @@ impl TableReference {
     pub fn has_qualifiers(&self) -> bool {
         self.catalog.is_some() || self.schema.is_some()
     }
-    pub fn try_from_name_and_alias(name: &ObjectName, alias: &Option<Ident>) -> Result<Self, Error> {
+    pub fn try_from_name_and_alias(
+        name: &ObjectName,
+        alias: &Option<Ident>,
+    ) -> Result<Self, Error> {
         match name.0.len() {
             0 => unreachable!("Parser should not allow empty identifiers"),
             1 => Ok(TableReference {
@@ -116,7 +122,9 @@ impl TryFrom<&TableFactor> for TableReference {
 
     fn try_from(table: &TableFactor) -> Result<Self, Self::Error> {
         match table {
-            TableFactor::Table { name, alias, .. } => Self::try_from_name_and_alias(name, &alias.as_ref().map(|a| a.name.clone())),
+            TableFactor::Table { name, alias, .. } => {
+                Self::try_from_name_and_alias(name, &alias.as_ref().map(|a| a.name.clone()))
+            }
             _ => unreachable!("TableFactor::Table expected"),
         }
     }
@@ -251,7 +259,8 @@ mod tests {
         dialects: Vec<Box<dyn Dialect>>,
     ) {
         for dialect in dialects {
-            let result = TableExtractor::extract(dialect.as_ref(), sql).expect(&format!("parse failed for dialect: {dialect:?}"));
+            let result = TableExtractor::extract(dialect.as_ref(), sql)
+                .expect(&format!("parse failed for dialect: {dialect:?}"));
             assert_eq!(result, expected, "Failed for dialect: {dialect:?}")
         }
     }
@@ -417,7 +426,11 @@ mod tests {
                 },
             ]))];
             // BigQuery and Generic do not support DELETE ... FROM
-            assert_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
+            assert_table_extraction(
+                sql,
+                expected,
+                all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]),
+            );
         }
 
         #[test]
@@ -444,7 +457,11 @@ mod tests {
                 },
             ]))];
             // BigQuery and Generic do not support DELETE ... FROM
-            assert_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
+            assert_table_extraction(
+                sql,
+                expected,
+                all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]),
+            );
         }
 
         #[test]
@@ -484,7 +501,11 @@ mod tests {
                 },
             ]))];
             // BigQuery and Generic do not support DELETE ... FROM
-            assert_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
+            assert_table_extraction(
+                sql,
+                expected,
+                all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]),
+            );
         }
 
         #[test]

--- a/sql-insight/src/extractor/table_extractor.rs
+++ b/sql-insight/src/extractor/table_extractor.rs
@@ -395,6 +395,8 @@ mod tests {
     }
 
     mod delete_statement {
+        use crate::test_utils::all_dialects_except;
+
         use super::*;
 
         #[test]
@@ -414,7 +416,8 @@ mod tests {
                     alias: None,
                 },
             ]))];
-            assert_table_extraction(sql, expected, all_dialects());
+            // BigQuery and Generic do not support DELETE ... FROM
+            assert_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
         }
 
         #[test]
@@ -440,7 +443,8 @@ mod tests {
                     alias: Some("t2_alias".into()),
                 },
             ]))];
-            assert_table_extraction(sql, expected, all_dialects());
+            // BigQuery and Generic do not support DELETE ... FROM
+            assert_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
         }
 
         #[test]
@@ -479,7 +483,8 @@ mod tests {
                     alias: None,
                 },
             ]))];
-            assert_table_extraction(sql, expected, all_dialects());
+            // BigQuery and Generic do not support DELETE ... FROM
+            assert_table_extraction(sql, expected, all_dialects_except(&vec!["GenericDialect", "BigQueryDialect"]));
         }
 
         #[test]

--- a/sql-insight/src/test_utils.rs
+++ b/sql-insight/src/test_utils.rs
@@ -19,7 +19,10 @@ pub fn all_dialects() -> Vec<Box<dyn Dialect>> {
 }
 
 pub fn all_dialects_except(exclude: &Vec<&'static str>) -> Vec<Box<dyn Dialect>> {
-    all_dialects().into_iter().filter(|d| !exclude.contains(&format!("{:?}", d).as_str())).collect()
+    all_dialects()
+        .into_iter()
+        .filter(|d| !exclude.contains(&format!("{:?}", d).as_str()))
+        .collect()
 }
 
 pub static ALL_DIALECT_NAMES: [&str; 12] = [

--- a/sql-insight/src/test_utils.rs
+++ b/sql-insight/src/test_utils.rs
@@ -18,6 +18,10 @@ pub fn all_dialects() -> Vec<Box<dyn Dialect>> {
     ]
 }
 
+pub fn all_dialects_except(exclude: &Vec<&'static str>) -> Vec<Box<dyn Dialect>> {
+    all_dialects().into_iter().filter(|d| !exclude.contains(&format!("{:?}", d).as_str())).collect()
+}
+
 pub static ALL_DIALECT_NAMES: [&str; 12] = [
     "Generic",
     "MySQL",


### PR DESCRIPTION
This PR upgrades the sqlparser dependency to 0.56.0.

There were a few straightforward changes in the sqlparser API:
 - `Statement::Insert`, `Statement::Delete`, and `FromTable` have an additional layer of wrapping
 - `Statement::Insert` can now insert to a table or a table function
 - `MergeClause` now puts its action in a separate `action` field
 - `Expr::Value` now expects a `ValueWithSpan`

I took the opportunity to consolidate some duplicated code in constructing `TableReference` from various kinds of identifiers.

I also had to disable six tests for various dialects:
 - `DELETE <tables> FROM <tables>` is no longer valid syntax in the Generic or BigQuery dialects
 - The MsSql dialect treats `TRUE` and `FALSE` as identifiers rather than constants, so they don't get normalized

To support that, I added an `all_dialects_except(...)` helper to the test suite.

`cargo fmt` and `cargo clippy` both pass.