### PR TITLE
Add library MSRV verification

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -39,6 +39,18 @@ jobs:
       - uses: actions/checkout@v6
       - run: cargo check --all-targets --all-features
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install cargo-msrv
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - name: Verify sql-insight MSRV
+        working-directory: sql-insight
+        run: cargo msrv verify
+
   docs:
     runs-on: ubuntu-latest
     env:

--- a/sql-insight/Cargo.toml
+++ b/sql-insight/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 readme = "README.md"
 version = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.89.0"
 homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
@@ -24,5 +25,3 @@ path = "src/lib.rs"
 [dependencies]
 sqlparser = { version = "0.56.0", features = ["visitor"] }
 thiserror = "1.0.56"
-
-


### PR DESCRIPTION
## Summary
- declare Rust 1.89.0 as the MSRV for the sql-insight library crate
- add a cargo-msrv CI job for the library crate
- leave the CLI crate and Cargo.lock policy unchanged

## Why 1.89.0
This repository does not commit Cargo.lock because the library crate is the primary package. With lock-free dependency resolution, the current sqlparser 0.56.0 dependency tree resolves to recent compatible transitive crates.

Rust 1.70.0 cannot parse a transitive dependency using edition 2024, and Rust 1.85.0 still fails to compile the current transitive ar_archive_writer 0.5.1 due to let-chain syntax. Rust 1.89.0 is the lowest version verified locally against the current lock-free dependency resolution.

## Verification
- actionlint .github/workflows/rust.yaml
- cargo check --all-targets --all-features
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- rustup run stable cargo check --manifest-path sql-insight/Cargo.toml --all-features in a Cargo.lock-free temporary copy