### PR TITLE
Extraction correctness: NATURAL join fan-in, ordered-set lineage, CRUD / diagnostic / normalizer fixes

### DIFF
--- a/sql-insight/src/catalog.rs
+++ b/sql-insight/src/catalog.rs
@@ -28,6 +28,7 @@
 //! as actually stored (e.g. what `information_schema` reports); the
 //! resolver's dialect-casing policy governs the comparison.
 
+use crate::casing::IdentifierCasing;
 use crate::error::Error;
 use sqlparser::ast::{Ident, Statement};
 use sqlparser::dialect::Dialect;
@@ -108,6 +109,21 @@ impl Catalog {
     /// // `users` registered schema-less; `app.orders` keeps its schema.
     /// ```
     pub fn from_ddl(dialect: &dyn Dialect, ddl: &str) -> Result<Self, Error> {
+        Self::from_ddl_with_casing(dialect, ddl, IdentifierCasing::for_dialect(dialect))
+    }
+
+    /// Like [`from_ddl`](Self::from_ddl) but normalizes the stored identifiers
+    /// with an explicit `casing` instead of the dialect default. Pass the same
+    /// [`IdentifierCasing`] you give the extractor via
+    /// [`ExtractorOptions::with_casing`](crate::extractor::ExtractorOptions::with_casing),
+    /// so the catalog's canonical form matches what a query reference folds to:
+    /// `from_ddl` (dialect default) only matches when the extraction also uses
+    /// the default, so a case-sensitive override needs this to resolve.
+    pub fn from_ddl_with_casing(
+        dialect: &dyn Dialect,
+        ddl: &str,
+        casing: IdentifierCasing,
+    ) -> Result<Self, Error> {
         let statements = Parser::parse_sql(dialect, ddl)?;
         // Normalize each DDL identifier to its stored form the way the dialect
         // would: an unquoted name folds (e.g. Postgres `Users` → `users`), a
@@ -116,7 +132,6 @@ impl Catalog {
         // `CREATE TABLE Users` would register `Users` and miss a folded query
         // `users` under a case-sensitive dialect. (Catalog names compare like
         // quoted identifiers, so they must already be in canonical form.)
-        let casing = crate::casing::IdentifierCasing::for_dialect(dialect);
         let mut catalog = Catalog::new();
         for statement in &statements {
             let Statement::CreateTable(create) = statement else {

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -10,8 +10,10 @@
 //! Write targets bucket by verb, so DDL lands where its effect is, not in
 //! `Read`: `INSERT`, `CREATE TABLE` / `CREATE VIEW`, and `SELECT … INTO` →
 //! Create (an upsert `INSERT … ON CONFLICT DO UPDATE` / `ON DUPLICATE KEY
-//! UPDATE` also → Update), `UPDATE` and `ALTER` → Update, `DELETE` / `DROP` /
-//! `TRUNCATE` → Delete, and `MERGE` to each bucket its WHEN actions imply. A
+//! UPDATE` also → Update; `REPLACE INTO` / `INSERT OVERWRITE`, which delete the
+//! conflicting / existing rows first, also → Delete), `UPDATE` and `ALTER` →
+//! Update, `DELETE` / `DROP` / `TRUNCATE` → Delete, and `MERGE` to each bucket
+//! its WHEN actions imply. A
 //! statement's
 //! read-role tables (a `SELECT`, a CTAS / view source, an `UPDATE … FROM`)
 //! always go to Read. A `WITH … <DML>` parses as a `Query`-wrapped DML, so
@@ -156,6 +158,12 @@ impl CrudTableExtractor {
                 // `DO NOTHING`) is create-only.
                 if insert_updates {
                     crud.update_tables = writes.clone();
+                }
+                // `REPLACE INTO` / `INSERT OVERWRITE` delete the conflicting /
+                // existing rows of the target before inserting, so the target is
+                // also a delete (unlike an upsert, which updates in place).
+                if matches!(statement, Statement::Insert(i) if i.replace_into || i.overwrite) {
+                    crud.delete_tables = writes.clone();
                 }
                 crud.create_tables = writes;
                 crud.read_tables = reads;

--- a/sql-insight/src/normalizer.rs
+++ b/sql-insight/src/normalizer.rs
@@ -34,7 +34,7 @@ use std::ops::{ControlFlow, Deref};
 
 use crate::error::Error;
 use sqlparser::ast::{Expr, Insert, Statement, VisitMut, VisitorMut};
-use sqlparser::ast::{Query, SetExpr, Value};
+use sqlparser::ast::{Query, SetExpr, TopQuantity, Value};
 use sqlparser::dialect::Dialect;
 use sqlparser::parser::Parser;
 use std::ops::DerefMut;
@@ -129,6 +129,10 @@ impl VisitorMut for Normalizer {
     type Break = ();
 
     fn post_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        // `SELECT TOP 10`'s quantity is a bare `u64` (`TopQuantity::Constant`),
+        // not a `Value`, so the visitor's literal pass doesn't reach it — unlike
+        // `TOP (expr)` / `LIMIT`. Normalize it here so `TOP 10` becomes `TOP ?`.
+        normalize_top(query.body.deref_mut());
         if let SetExpr::Values(values) = query.body.deref_mut() {
             if self.options.unify_values {
                 let rows = &mut values.rows;
@@ -265,5 +269,28 @@ impl Normalizer {
             Expr::Tuple(v) => v.iter().all(Self::contains_only_tuples_of_values),
             _ => false,
         }
+    }
+}
+
+/// Replace a `SELECT TOP 10`-style constant quantity with a `?` placeholder
+/// (rendered `TOP ?`), recursing into set-operation branches. A bare
+/// `TopQuantity::Constant(u64)` isn't a `Value`, so the visitor's literal pass
+/// misses it; `TopQuantity::Expr` is already normalized by that pass.
+fn normalize_top(body: &mut SetExpr) {
+    match body {
+        SetExpr::Select(select) => {
+            if let Some(top) = &mut select.top {
+                if matches!(top.quantity, Some(TopQuantity::Constant(_))) {
+                    top.quantity = Some(TopQuantity::Expr(Expr::Value(
+                        Value::Placeholder("?".into()).with_empty_span(),
+                    )));
+                }
+            }
+        }
+        SetExpr::SetOperation { left, right, .. } => {
+            normalize_top(left);
+            normalize_top(right);
+        }
+        _ => {}
     }
 }

--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -237,11 +237,11 @@ impl<'a> Binder<'a> {
     /// statement then binds to nothing, so an `UnsupportedStatement` (it
     /// projects to the table level) signals the empty surfaces are a coverage
     /// gap, not "nothing there". `message` shows the offending target.
-    pub(super) fn record_unsupported_merge_target(&mut self, factor: &TableFactor) {
+    pub(super) fn record_unsupported_dml_target(&mut self, statement: &str, factor: &TableFactor) {
         self.diagnostics.push(ColumnLevelDiagnostic {
             kind: ColumnLevelDiagnosticKind::UnsupportedStatement,
             message: format!(
-                "MERGE target `{factor}` is not a plain table (a derived table / subquery / table function) — the statement can't be analyzed and is dropped"
+                "{statement} target `{factor}` is not a plain table (a derived table / subquery / table function) — the statement can't be analyzed and is dropped"
             ),
             span: None,
         });

--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -767,6 +767,12 @@ fn join_using(op: &JoinOperator) -> Vec<Ident> {
     }
 }
 
+/// Whether a join is `NATURAL` — its merge columns are the schema-common ones
+/// (computed from both sides' known columns), not an explicit `USING` list.
+fn join_is_natural(op: &JoinOperator) -> bool {
+    matches!(join_constraint(op), Some(JoinConstraint::Natural))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -488,7 +488,11 @@ impl<'a> Binder<'a> {
         if let Some(filter) = &function.filter {
             suppressed.push(self.bind_expr(filter, scope));
         }
-        suppressed.extend(
+        // `WITHIN GROUP (ORDER BY expr)` keys an ordered-set aggregate
+        // (`percentile_cont(0.5) WITHIN GROUP (ORDER BY salary)` → the
+        // percentile *of* salary) — `expr` is the aggregated value, so it's a
+        // value operand (an origin), not a row-positioning filter.
+        args.extend(
             function
                 .within_group
                 .iter()
@@ -496,8 +500,8 @@ impl<'a> Binder<'a> {
         );
         // A window function `f(args) OVER (…)` is an `Expr::Window`: the value
         // arguments flow (a transformation), the PARTITION BY / ORDER BY keys
-        // (+ frame bounds) and any FILTER / WITHIN GROUP are row-positioning
-        // (filter — reads, never origins).
+        // (+ frame bounds) and any FILTER are row-positioning (filter — reads,
+        // never origins).
         match &function.over {
             Some(WindowType::WindowSpec(spec)) => {
                 let partition = spec

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -535,10 +535,17 @@ impl<'a> Binder<'a> {
             // inputs accumulated so far.
             let visible: Vec<Relation> = left.iter().chain(&scope.relations).cloned().collect();
             let (right, right_scope) = self.bind_table_factor(&j.relation, &visible);
+            // Merge columns — an unqualified reference to one fans in to both
+            // sides. An explicit `USING (col)` names them; a NATURAL join takes
+            // the two sides' schema-common columns (so it needs a catalog —
+            // computed before the right scope is absorbed into the left).
+            let merge = if join_is_natural(&j.join_operator) {
+                self.natural_merge_columns(&scope, &right_scope)
+            } else {
+                join_using(&j.join_operator)
+            };
             scope.absorb(right_scope);
-            // A `USING (col)` join records its merge columns: an unqualified
-            // reference to one fans in to both sides.
-            scope.add_merge_columns(join_using(&j.join_operator));
+            scope.add_merge_columns(merge);
             // The ON predicate resolves against both sides' columns.
             let on = join_on(&j.join_operator)
                 .map(|e| self.bind_expr(e, &scope))
@@ -547,6 +554,32 @@ impl<'a> Binder<'a> {
             node = join(node, right, on);
         }
         (node, scope)
+    }
+
+    /// A NATURAL join's merge columns: the column names exposed by *both* sides
+    /// (the schema intersection, case-folded). Catalog-only — a side with no
+    /// known column list (a catalog-free table, an opaque table function)
+    /// contributes nothing, so a catalog-free NATURAL join yields no merge
+    /// columns (an unqualified reference stays ambiguous rather than fanning in).
+    fn natural_merge_columns(&self, left: &Scope, right: &Scope) -> Vec<Ident> {
+        let right_columns: Vec<&Ident> = right
+            .relations
+            .iter()
+            .flat_map(|r| r.known_columns())
+            .collect();
+        let mut common: Vec<Ident> = Vec::new();
+        for column in left.relations.iter().flat_map(|r| r.known_columns()) {
+            let in_right = right_columns
+                .iter()
+                .any(|r| self.eq(self.style.casing.column, column, r));
+            let already = common
+                .iter()
+                .any(|c| self.eq(self.style.casing.column, c, column));
+            if in_right && !already {
+                common.push(column.clone());
+            }
+        }
+        common
     }
 
     /// Bind a bare named table into a read `Scan` plus a single-relation scope

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -50,10 +50,18 @@ impl<'a> Binder<'a> {
         let name = cte.alias.name.clone();
         let inner_env = if recursive {
             let provisional = match cte.query.body.as_ref() {
-                SetExpr::SetOperation { left, .. } => self
-                    .in_ctes(env.to_vec(), |b| b.bind_set_expr(left))
-                    .1
-                    .exposed_columns(Some(&cte.alias)),
+                SetExpr::SetOperation { left, .. } => {
+                    // This binds the anchor only to learn its column shape; the
+                    // real bind below binds it again, so discard any diagnostics
+                    // it raises here — otherwise they'd be reported twice.
+                    let saved = self.diagnostics.len();
+                    let columns = self
+                        .in_ctes(env.to_vec(), |b| b.bind_set_expr(left))
+                        .1
+                        .exposed_columns(Some(&cte.alias));
+                    self.diagnostics.truncate(saved);
+                    columns
+                }
                 _ => Vec::new(),
             };
             let mut e = env.to_vec();

--- a/sql-insight/src/resolver/binder/scope.rs
+++ b/sql-insight/src/resolver/binder/scope.rs
@@ -165,4 +165,23 @@ impl Relation {
             Relation::Derived { alias, .. } | Relation::TableFunction { alias } => alias.as_ref(),
         }
     }
+
+    /// The column names this relation is *known* to expose — a `Cataloged`
+    /// table's columns, or a derived relation's exposed columns. An `Unknown`
+    /// (catalog-free) table or an opaque table function has no known list, so it
+    /// contributes nothing to a NATURAL join's schema-common columns.
+    pub(super) fn known_columns(&self) -> &[Ident] {
+        match self {
+            Relation::Table {
+                columns: Columns::Cataloged(cols),
+                ..
+            } => cols,
+            Relation::Derived { columns, .. } => columns,
+            Relation::Table {
+                columns: Columns::Unknown,
+                ..
+            }
+            | Relation::TableFunction { .. } => &[],
+        }
+    }
 }

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -349,6 +349,14 @@ impl<'a> Binder<'a> {
         // The root's own resolution isn't needed here — each SET assignment
         // carries its write-target table's resolution (`assignment_target`).
         let Some((target_relation, target, _)) = self.target_relation(target_factor) else {
+            // A non-table target (derived table / subquery / table function)
+            // can't be a write target — flag it (like `bind_merge`) rather than
+            // dropping silently. A plain table that failed to resolve is already
+            // flagged by `table_ref` (e.g. too many qualifiers), so don't
+            // double-report it.
+            if !matches!(target_factor, TableFactor::Table { .. }) {
+                self.record_unsupported_dml_target("UPDATE", target_factor);
+            }
             return LogicalPlan::Empty;
         };
         let mut scope = Scope::single(target_relation);
@@ -502,7 +510,7 @@ impl<'a> Binder<'a> {
         // silently picking the first relation. A parenthesized *single* table
         // `(t1)` is fine and resolves below.
         if is_join_factor(&merge.table) {
-            self.record_unsupported_merge_target(&merge.table);
+            self.record_unsupported_dml_target("MERGE", &merge.table);
             return LogicalPlan::Empty;
         }
         let Some((target_relation, target, target_resolution)) = self.target_relation(&merge.table)
@@ -510,7 +518,7 @@ impl<'a> Binder<'a> {
             // A non-table MERGE target (derived table / subquery / table
             // function) can't be a write target — flag it rather than dropping
             // the whole statement silently (best-effort drop + flag).
-            self.record_unsupported_merge_target(&merge.table);
+            self.record_unsupported_dml_target("MERGE", &merge.table);
             return LogicalPlan::Empty;
         };
         let mut scope = Scope::single(target_relation);

--- a/sql-insight/tests/catalog.rs
+++ b/sql-insight/tests/catalog.rs
@@ -374,6 +374,48 @@ fn from_ddl_folds_unquoted_identifiers_to_their_stored_form() {
 }
 
 #[test]
+fn from_ddl_with_casing_aligns_the_catalog_with_a_casing_override() {
+    // Under a `with_casing(Sensitive)` extraction override, a default `from_ddl`
+    // (folding with the dialect default) no longer matches — its canonical form
+    // differs from what the Sensitive query folds to. `from_ddl_with_casing`
+    // builds the catalog with the same casing, so it matches.
+    use sql_insight::sqlparser::dialect::PostgreSqlDialect;
+    use sql_insight::{CaseRule, IdentifierCasing};
+    let sensitive = IdentifierCasing::uniform(CaseRule::Sensitive);
+    let resolution = |catalog: &Catalog| -> ResolutionKind {
+        extract_column_operations_with_options(
+            &PostgreSqlDialect {},
+            "SELECT a FROM MyTable",
+            ExtractorOptions::new()
+                .with_catalog(catalog)
+                .with_casing(sensitive),
+        )
+        .unwrap()
+        .remove(0)
+        .unwrap()
+        .reads
+        .first()
+        .unwrap()
+        .resolution
+    };
+
+    // Default `from_ddl` folds `MyTable` → `mytable`; the Sensitive query keeps
+    // `MyTable`, so it misses.
+    let default = Catalog::from_ddl(&PostgreSqlDialect {}, "CREATE TABLE MyTable (a INT)").unwrap();
+    assert_eq!(resolution(&default), ResolutionKind::Inferred);
+
+    // Built with the same Sensitive casing, the catalog stores `MyTable` exact,
+    // so the Sensitive query matches.
+    let aligned = Catalog::from_ddl_with_casing(
+        &PostgreSqlDialect {},
+        "CREATE TABLE MyTable (a INT)",
+        sensitive,
+    )
+    .unwrap();
+    assert_eq!(resolution(&aligned), ResolutionKind::Cataloged);
+}
+
+#[test]
 fn from_ddl_unquoted_registration_canonicalizes_the_surfaced_identity() {
     // The Cataloged read surfaces the catalog's stored (folded) identity, not
     // the query's written casing.

--- a/sql-insight/tests/column_operation_extractor/arm_coverage.rs
+++ b/sql-insight/tests/column_operation_extractor/arm_coverage.rs
@@ -196,6 +196,17 @@ mod expr_arm_coverage {
     }
 
     #[test]
+    fn within_group_aggregated_value_flows_to_output() {
+        // An ordered-set aggregate's `WITHIN GROUP (ORDER BY a)` key is the
+        // aggregated value (`percentile_cont` of `a`), so `a` reads *and* flows
+        // to the output (Transformation) — unlike a function's internal
+        // `ORDER BY` (a row-positioning filter).
+        let sql = "SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY t.a) AS med FROM t";
+        assert_unordered_eq!(reads(sql), vec![c("a")]);
+        assert_unordered_eq!(lineage(sql), vec![transformation(c("a"), out("med", 0))]);
+    }
+
+    #[test]
     fn listagg_on_overflow_error() {
         assert_unordered_eq!(
             reads("SELECT LISTAGG(t.a, ',' ON OVERFLOW ERROR) FROM t"),

--- a/sql-insight/tests/column_operation_extractor/diagnostics.rs
+++ b/sql-insight/tests/column_operation_extractor/diagnostics.rs
@@ -19,6 +19,22 @@ mod reported {
     }
 
     #[test]
+    fn recursive_cte_anchor_diagnostic_is_not_duplicated() {
+        // A recursive CTE binds its anchor twice (once to learn its column
+        // shape, once for real); a diagnostic the anchor raises must surface
+        // only once, not per bind. (Focused on the diagnostic — the recursive
+        // body's reads / lineage are pinned elsewhere.)
+        let op = extract(
+            "WITH RECURSIVE r AS (SELECT id FROM a.b.c.d UNION SELECT id FROM r) SELECT id FROM r",
+        );
+        let kinds: Vec<_> = op.diagnostics.iter().map(|d| d.kind.clone()).collect();
+        assert_eq!(
+            kinds,
+            vec![ColumnLevelDiagnosticKind::TooManyTableQualifiers]
+        );
+    }
+
+    #[test]
     fn update_non_table_target_reports_diagnostic() {
         // A derived / subquery UPDATE target can't be a write target — flagged
         // (like a MERGE into a non-table target), not dropped silently. The

--- a/sql-insight/tests/column_operation_extractor/diagnostics.rs
+++ b/sql-insight/tests/column_operation_extractor/diagnostics.rs
@@ -19,6 +19,23 @@ mod reported {
     }
 
     #[test]
+    fn update_non_table_target_reports_diagnostic() {
+        // A derived / subquery UPDATE target can't be a write target — flagged
+        // (like a MERGE into a non-table target), not dropped silently. The
+        // statement_kind stays Update; nothing is written.
+        assert_column_ops(
+            "UPDATE (SELECT 1) x SET a = 1",
+            ColumnOperation {
+                statement_kind: StatementKind::Update,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
     fn over_qualified_read_table_reports_diagnostic() {
         // A FROM table with more than `catalog.schema.name` segments can't
         // be represented, so it's dropped (the projected `a` is left

--- a/sql-insight/tests/column_operation_extractor/joins_sets.rs
+++ b/sql-insight/tests/column_operation_extractor/joins_sets.rs
@@ -425,8 +425,10 @@ mod join_using_and_natural {
     //! a USING column resolves to *every* joined relation that could own
     //! it (the COALESCE-style merged column has no single owner), so it
     //! surfaces one read / lineage source per side rather than an
-    //! ambiguous `table: None`. NATURAL JOIN stays unexpanded (its merge
-    //! set needs both schemas, like wildcard expansion).
+    //! ambiguous `table: None`. A NATURAL JOIN fans in the same way, but its
+    //! merge set is the schema intersection of both sides — knowable only with
+    //! a catalog (covered in `resolution`); catalog-free, it can't expand and an
+    //! unqualified ref stays ambiguous.
     use super::*;
 
     #[test]

--- a/sql-insight/tests/column_operation_extractor/resolution.rs
+++ b/sql-insight/tests/column_operation_extractor/resolution.rs
@@ -367,6 +367,32 @@ mod catalog_strict {
     }
 
     #[test]
+    fn catalog_natural_join_fans_in_schema_common_columns() {
+        // A NATURAL join's merge set is the schema intersection of both sides —
+        // knowable only with a catalog. `id` is common to t1 and t2, so an
+        // unqualified `id` fans in to both (like USING (id)); the unique columns
+        // (`a`, `b`) are not merge columns. (Catalog-free, `id` stays ambiguous
+        // — see `joins_sets`.)
+        let catalog = TestCatalog::default()
+            .with("t1", vec!["id", "a"])
+            .with("t2", vec!["id", "b"]);
+        assert_column_ops_with_catalog(
+            "SELECT id FROM t1 NATURAL JOIN t2",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read_confirmed("t1", "id"), read_confirmed("t2", "id")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col_confirmed("t1", "id"), out("id", 0)),
+                    passthrough(col_confirmed("t2", "id"), out("id", 0)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn catalog_disambiguates_join_unqualified_ref() {
         // Both tables are Known via catalog; only t2 has `a`, so
         // unqualified `a` in `t1 JOIN t2` resolves to t2 (no

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -411,6 +411,38 @@ mod insert_statement {
         })];
         assert_crud_table_extraction(sql, expected, vec![Box::new(MySqlDialect {})]);
     }
+
+    #[test]
+    fn test_replace_into_buckets_target_as_create_and_delete() {
+        // `REPLACE INTO` deletes the conflicting row before inserting (unlike an
+        // upsert, which updates in place), so `t1` lands in both create and
+        // delete.
+        let sql = "REPLACE INTO t1 (a) VALUES (1)";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("t1"))],
+            read_tables: vec![],
+            update_tables: vec![],
+            delete_tables: vec![cwrite(table("t1"))],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, vec![Box::new(MySqlDialect {})]);
+    }
+
+    #[test]
+    fn test_insert_overwrite_buckets_target_as_create_and_delete() {
+        use sql_insight::sqlparser::dialect::GenericDialect;
+        // `INSERT OVERWRITE` replaces the target's existing data, so `t1` lands
+        // in both create and delete; the `SELECT` source `s` is a read.
+        let sql = "INSERT OVERWRITE t1 SELECT a FROM s";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("t1"))],
+            read_tables: vec![cread(table("s"))],
+            update_tables: vec![],
+            delete_tables: vec![cwrite(table("t1"))],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, vec![Box::new(GenericDialect {})]);
+    }
 }
 
 mod update_statement {

--- a/sql-insight/tests/normalizer.rs
+++ b/sql-insight/tests/normalizer.rs
@@ -1,5 +1,5 @@
 use sql_insight::normalizer::*;
-use sql_insight::sqlparser::dialect::Dialect;
+use sql_insight::sqlparser::dialect::{Dialect, MsSqlDialect};
 use sql_insight::test_utils::{all_dialects, all_dialects_except, DialectName};
 
 fn assert_normalize(
@@ -31,6 +31,27 @@ fn test_multiple_sql() {
         "DELETE FROM t3 WHERE c = ?".into(),
     ];
     assert_normalize(sql, expected, all_dialects(), NormalizerOptions::new());
+}
+
+#[test]
+fn test_top_constant_is_normalized() {
+    // `TOP 5`'s quantity is a bare `u64` (not a `Value`), so it needs explicit
+    // handling — without it, `TOP 5` / `TOP 10` would fingerprint differently
+    // (unlike `LIMIT`). It collapses to the same form as `TOP (expr)`.
+    let mssql = || -> Vec<Box<dyn Dialect>> { vec![Box::new(MsSqlDialect {})] };
+    assert_normalize(
+        "SELECT TOP 5 a FROM t",
+        vec!["SELECT TOP (?) a FROM t".into()],
+        mssql(),
+        NormalizerOptions::new(),
+    );
+    // `TOP 5` and the parenthesized `TOP (10)` normalize identically.
+    assert_normalize(
+        "SELECT TOP (10) a FROM t",
+        vec!["SELECT TOP (?) a FROM t".into()],
+        mssql(),
+        NormalizerOptions::new(),
+    );
 }
 
 #[test]


### PR DESCRIPTION
A second batch of extraction-correctness fixes, each its own commit with regression tests. The full suite stays green (685) and the CI quartet (fmt / clippy `-D warnings` / test / doc `-Dwarnings`) is clean throughout.

### Resolution / lineage

- **NATURAL JOIN merge columns fan in** — an unqualified reference to a NATURAL join's common column (`SELECT id FROM t1 NATURAL JOIN t2`) resolved `Ambiguous` instead of fanning in to both sides like `USING (id)`. Compute the merge set as the schema intersection of both sides' known columns and feed it through the existing USING fan-in path. Catalog-only — a side with no known column list (catalog-free table / opaque function) contributes none, so a catalog-free NATURAL join still can't expand.
- **Ordered-set aggregate `WITHIN GROUP` value flows** — `percentile_cont(0.5) WITHIN GROUP (ORDER BY salary)` aggregates `salary` (the percentile *of* it), but the `WITHIN GROUP` expression was bound as a filter, so `salary` read but never flowed to the output. Bind it as a value operand, so `salary → med` (Transformation). A function's internal `ORDER BY` (`ARRAY_AGG(a ORDER BY b)`) stays a filter.

### Diagnostics

- **Non-table UPDATE target is flagged** — `UPDATE (SELECT 1) x SET …` (a derived / subquery / table-function target) can't be a write target, so it was dropped — but, unlike MERGE, with no diagnostic. Flag it with `UnsupportedStatement` (a plain table that failed to resolve is already flagged by the table-ref path, so it isn't double-reported).
- **Recursive CTE anchor diagnostics aren't duplicated** — a recursive CTE binds its anchor twice (once to learn its column shape, once for real), so a diagnostic the anchor raised (e.g. too-many-qualifiers) was reported twice. Discard the provisional bind's diagnostics; the real bind re-emits them once.

### CRUD / normalizer / catalog

- **REPLACE / INSERT OVERWRITE bucket as Create + Delete** — both delete the conflicting / existing rows of the target before inserting, so the CRUD view now lists the target in `Delete` as well as `Create` (unlike an upsert, which updates in place → Create + Update).
- **`TOP n` constant is normalized** — `SELECT TOP 5`'s quantity is a bare `u64`, which the normalizer's literal pass never reached, so `TOP 5` / `TOP 10` fingerprinted differently (unlike `LIMIT`, and the parenthesized `TOP (expr)`). Replace a constant TOP quantity with a `?` placeholder.
- **`Catalog::from_ddl_with_casing`** — `from_ddl` normalizes stored identifiers with the dialect default, so a DDL-built catalog silently missed every lookup under a `with_casing` override (the canonical stored name no longer matched what the overridden query folds to). The new method takes an explicit `IdentifierCasing`; `from_ddl` delegates to it with the dialect default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
