### PR TITLE
fix: correct extraction edge cases in CTEs, DML targets, lineage, and catalog

### DIFF
--- a/sql-insight-cli/src/executor.rs
+++ b/sql-insight-cli/src/executor.rs
@@ -154,8 +154,12 @@ impl CliExecutable for ExtractExecutor {
     fn execute(&self) -> Result<Vec<String>, Error> {
         let dialect = get_dialect(self.dialect_name.as_deref())?;
         let dialect = dialect.as_ref();
-        let catalog = self.load_catalog(dialect)?;
+        // Resolve the casing override first: the catalog must be built with the
+        // same casing the extraction uses, or a `--casing` override silently
+        // breaks every catalog lookup (the stored identity wouldn't match what a
+        // query reference folds to).
         let casing = self.casing.resolve(dialect);
+        let catalog = self.load_catalog(dialect, casing)?;
 
         let mut options = ExtractorOptions::new();
         if let Some(catalog) = &catalog {
@@ -198,13 +202,21 @@ impl ExtractExecutor {
     /// — defaults alone still build a (table-less) catalog, so a bare ref
     /// qualifies to `--default-schema` even without a DDL file. Unqualified
     /// DDL tables register schema-less (no fabricated schema).
-    fn load_catalog(&self, dialect: &dyn Dialect) -> Result<Option<Catalog>, Error> {
+    fn load_catalog(
+        &self,
+        dialect: &dyn Dialect,
+        casing: Option<IdentifierCasing>,
+    ) -> Result<Option<Catalog>, Error> {
         if self.ddl_file.is_none()
             && self.default_schema.is_none()
             && self.default_catalog.is_none()
         {
             return Ok(None);
         }
+        // Register identifiers with the same casing the extraction uses (the
+        // `--casing` override, else the dialect default) so the catalog's
+        // canonical form matches what a query reference folds to.
+        let casing = casing.unwrap_or_else(|| IdentifierCasing::for_dialect(dialect));
         let mut catalog = match &self.ddl_file {
             Some(path) => {
                 let ddl = std::fs::read_to_string(path).map_err(|e| {
@@ -213,7 +225,7 @@ impl ExtractExecutor {
                 // Prefix the DDL-file context so a parse error in the catalog
                 // file isn't mistaken for one in the analysed query (whose own
                 // errors surface per-statement, unprefixed).
-                Catalog::from_ddl(dialect, &ddl).map_err(|e| {
+                Catalog::from_ddl_with_casing(dialect, &ddl, casing).map_err(|e| {
                     Error::ArgumentError(format!("Failed to parse DDL file {path}: {e}"))
                 })?
             }

--- a/sql-insight-cli/tests/integration.rs
+++ b/sql-insight-cli/tests/integration.rs
@@ -371,6 +371,32 @@ mod integration {
         }
 
         #[test]
+        fn test_ddl_file_catalog_uses_the_casing_override() {
+            // The `--ddl-file` catalog is built with the same `--casing` override
+            // as the extraction, so a lookup still matches. Under `--casing
+            // upper`, the registered table folds to `USERS` and the read is
+            // `(cataloged)` — without the override applied to the catalog, the
+            // dialect-default stored name wouldn't fold to the overridden query's
+            // and the lookup would silently miss.
+            let mut schema = NamedTempFile::new().unwrap();
+            schema.write_all(b"CREATE TABLE users (id INT);").unwrap();
+            sql_insight_cmd()
+                .arg("extract")
+                .arg("column-ops")
+                .arg("--casing")
+                .arg("upper")
+                .arg("--ddl-file")
+                .arg(schema.path())
+                .arg("SELECT id FROM users")
+                .assert()
+                .success()
+                .stdout(
+                    "[1] Select\n  reads:   \"USERS\".id (cataloged)\n  lineage: \"USERS\".id (cataloged) -> id\n",
+                )
+                .stderr("");
+        }
+
+        #[test]
         fn test_write_target_shows_catalog_resolution() {
             // A DML write target carries the catalog match too: the registered
             // `users` insert target prints `(cataloged)`, like a read would.

--- a/sql-insight/src/catalog.rs
+++ b/sql-insight/src/catalog.rs
@@ -141,7 +141,20 @@ impl Catalog {
             if create.columns.is_empty() {
                 continue;
             }
-            let parts: Vec<&Ident> = create.name.0.iter().filter_map(|p| p.as_ident()).collect();
+            // Every name segment must be a plain identifier. A non-identifier
+            // segment (e.g. Snowflake `IDENTIFIER('t')`) makes the table's
+            // identity unrepresentable — skip the whole CREATE rather than
+            // dropping the segment and registering a mis-segmented phantom (an
+            // `s.IDENTIFIER('t')` would otherwise register as table `s`).
+            let Some(parts) = create
+                .name
+                .0
+                .iter()
+                .map(|p| p.as_ident())
+                .collect::<Option<Vec<&Ident>>>()
+            else {
+                continue;
+            };
             let name = |id: &Ident| casing.table.normalize(id);
             let table = match parts.as_slice() {
                 [n] => CatalogTable::unqualified(name(n)),

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -27,7 +27,7 @@ use crate::diagnostic::TableLevelDiagnostic;
 use crate::error::Error;
 use crate::extractor::{ExtractorOptions, StatementKind, TableOperationExtractor};
 use crate::reference::{TableRead, TableReference, TableWrite};
-use sqlparser::ast::Statement;
+use sqlparser::ast::{Insert, SetExpr, Statement};
 use sqlparser::dialect::Dialect;
 
 /// Parse `sql` under `dialect` and return one [`CrudTables`] per
@@ -168,8 +168,10 @@ impl CrudTableExtractor {
                 }
                 // `REPLACE INTO` / `INSERT OVERWRITE` delete the conflicting /
                 // existing rows of the target before inserting, so the target is
-                // also a delete (unlike an upsert, which updates in place).
-                if matches!(statement, Statement::Insert(i) if i.replace_into || i.overwrite) {
+                // also a delete (unlike an upsert, which updates in place). Peel
+                // a `WITH … INSERT OVERWRITE …` wrapper (parsed as a Query-
+                // wrapped Insert) so the flags are read off the real insert.
+                if peel_to_insert(statement).is_some_and(|i| i.replace_into || i.overwrite) {
                     crud.delete_tables = writes.clone();
                 }
                 crud.create_tables = writes;
@@ -256,5 +258,27 @@ impl CrudTableExtractor {
         }
 
         Ok(crud)
+    }
+}
+
+/// The underlying `INSERT` of a statement, peeling a `WITH` / parenthesis
+/// wrapper. `WITH … INSERT OVERWRITE …` parses as a `Query`-wrapped `Insert`
+/// (the verb rides `query.body`), so the REPLACE / OVERWRITE flags must be read
+/// off the real insert, not the outer `Statement::Query`. `None` for any
+/// non-INSERT statement.
+fn peel_to_insert(statement: &Statement) -> Option<&Insert> {
+    match statement {
+        Statement::Insert(insert) => Some(insert),
+        Statement::Query(query) => {
+            let mut body = query.body.as_ref();
+            loop {
+                match body {
+                    SetExpr::Insert(inner) => return peel_to_insert(inner),
+                    SetExpr::Query(inner) => body = inner.body.as_ref(),
+                    _ => return None,
+                }
+            }
+        }
+        _ => None,
     }
 }

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -137,13 +137,20 @@ impl CrudTableExtractor {
         catalog: Option<&Catalog>,
         style: IdentifierStyle,
     ) -> Result<CrudTables, Error> {
-        let (ops, merge_actions, insert_updates) =
+        let (ops, merge_actions, insert_updates, cte_crud) =
             TableOperationExtractor::extract_inner(statement, catalog, style)?;
         // CRUD buckets carry the same `ResolutionKind` as the table operation:
         // reads as `TableRead`, the create / update / delete buckets as
         // `TableWrite`.
         let reads = ops.reads;
-        let writes = ops.writes;
+        // With data-modifying CTEs the flat write list spans several roots with
+        // different verbs, so the outer-kind match below must bucket only the
+        // outer root's *own* writes; each CTE's writes are added afterwards by
+        // that CTE's verb. Without them, the flat list is the outer's writes.
+        let writes = match &cte_crud {
+            Some(c) => c.outer_writes.clone(),
+            None => ops.writes,
+        };
         let diagnostics = ops.diagnostics;
 
         let mut crud = CrudTables {
@@ -237,6 +244,15 @@ impl CrudTableExtractor {
                         resolution: w.resolution,
                     }));
             }
+        }
+
+        // Each data-modifying CTE's write target lands in its own verb's bucket
+        // (an INSERT CTE → create, DELETE → delete, UPDATE → update), regardless
+        // of the outer kind handled above.
+        if let Some(c) = cte_crud {
+            crud.create_tables.extend(c.create);
+            crud.update_tables.extend(c.update);
+            crud.delete_tables.extend(c.delete);
         }
 
         Ok(crud)

--- a/sql-insight/src/extractor/table_operation_extractor.rs
+++ b/sql-insight/src/extractor/table_operation_extractor.rs
@@ -203,13 +203,22 @@ impl TableOperationExtractor {
         statement: &Statement,
         catalog: Option<&Catalog>,
         style: IdentifierStyle,
-    ) -> Result<(TableOperation, Option<MergeActions>, bool), Error> {
+    ) -> Result<
+        (
+            TableOperation,
+            Option<MergeActions>,
+            bool,
+            Option<crate::resolver::DataModifyingCteCrud>,
+        ),
+        Error,
+    > {
         let statement_kind = classify_statement(statement);
         if statement_kind == StatementKind::Unsupported {
             return Ok((
                 unsupported_table_operation(statement_kind, statement),
                 None,
                 false,
+                None,
             ));
         }
         let (plan, column_diagnostics) = crate::resolver::build(statement, catalog, style);
@@ -224,8 +233,12 @@ impl TableOperationExtractor {
         // target rows, so it moves no data even though the source is a
         // feeding input — read that off the IR-derived `MergeActions` rather
         // than re-walking the raw `Statement::Merge`.
-        let emits_lineage =
+        let outer_moves_data =
             writes_data(&statement_kind) && merge_actions.is_none_or(|a| a.writes_data());
+        // A data-modifying CTE (`WITH c AS (INSERT …) SELECT …`) moves data even
+        // though the statement classifies by its read outer verb, so it emits
+        // lineage independently of the outer kind / MERGE gate above.
+        let emits_lineage = outer_moves_data || crate::resolver::has_data_modifying_cte(&plan);
         let lineage = if emits_lineage {
             crate::resolver::table_lineage(&plan, style.casing)
         } else {
@@ -244,7 +257,8 @@ impl TableOperationExtractor {
                 .filter_map(|d| d.to_table_level())
                 .collect(),
         };
-        Ok((op, merge_actions, insert_updates))
+        let cte_crud = crate::resolver::data_modifying_cte_crud(&plan);
+        Ok((op, merge_actions, insert_updates, cte_crud))
     }
 }
 

--- a/sql-insight/src/resolver.rs
+++ b/sql-insight/src/resolver.rs
@@ -162,3 +162,84 @@ pub(crate) fn insert_updates_on_conflict(plan: &LogicalPlan) -> bool {
     use logical_plan::peel_with;
     matches!(peel_with(plan), LogicalPlan::Insert(i) if !i.on_conflict.is_empty())
 }
+
+/// Whether the statement carries a *data-modifying CTE* — a write root that
+/// isn't the outer root (`WITH c AS (INSERT … RETURNING …) SELECT … FROM c`).
+/// Such a statement classifies by its outer verb (often a read `SELECT`) yet
+/// still moves data, so the lineage gate must look past the outer kind.
+pub(crate) fn has_data_modifying_cte(plan: &LogicalPlan) -> bool {
+    use logical_plan::{dml_roots, peel_with};
+    let outer = peel_with(plan);
+    dml_roots(plan)
+        .iter()
+        .any(|root| !std::ptr::eq(*root, outer))
+}
+
+/// The CRUD-bucket contribution of a statement's *data-modifying CTEs* — each
+/// CTE body's write target placed in the bucket its own verb implies (INSERT →
+/// create, UPDATE → update, DELETE → delete), independent of the outer verb that
+/// `StatementKind` reports. `outer_writes` carries the outer root's *own* write
+/// targets so the CRUD extractor buckets them by the outer kind (not the flat
+/// union of all roots, which would mis-place the CTE writes). `None` when the
+/// statement has no data-modifying CTE — the flat write list is already correct.
+pub(crate) struct DataModifyingCteCrud {
+    pub(crate) create: Vec<TableWrite>,
+    pub(crate) update: Vec<TableWrite>,
+    pub(crate) delete: Vec<TableWrite>,
+    pub(crate) outer_writes: Vec<TableWrite>,
+}
+
+pub(crate) fn data_modifying_cte_crud(plan: &LogicalPlan) -> Option<DataModifyingCteCrud> {
+    use logical_plan::{dml_roots, peel_with};
+    let outer = peel_with(plan);
+    let roots = dml_roots(plan);
+    if roots.iter().all(|root| std::ptr::eq(*root, outer)) {
+        return None;
+    }
+    let mut crud = DataModifyingCteCrud {
+        create: Vec::new(),
+        update: Vec::new(),
+        delete: Vec::new(),
+        outer_writes: Vec::new(),
+    };
+    for root in roots {
+        let targets = tables::write_root_tables(root);
+        if std::ptr::eq(root, outer) {
+            crud.outer_writes = targets;
+            continue;
+        }
+        match root {
+            // An upsert CTE both inserts and updates, like the outer-root upsert.
+            LogicalPlan::Insert(i) => {
+                crud.create.extend(targets.iter().cloned());
+                if !i.on_conflict.is_empty() {
+                    crud.update.extend(targets);
+                }
+            }
+            LogicalPlan::Update(_) | LogicalPlan::AlterTable(_) => crud.update.extend(targets),
+            LogicalPlan::Delete(_) | LogicalPlan::Drop(_) => crud.delete.extend(targets),
+            LogicalPlan::CreateTableAs(_) | LogicalPlan::CreateView(_) => {
+                crud.create.extend(targets)
+            }
+            // A MERGE can't appear as a CTE body in practice; bucket its target
+            // conservatively as a write rather than dropping it.
+            LogicalPlan::Merge(_) => crud.create.extend(targets),
+            // Not a write root — contributes nothing. Listed so a new variant
+            // forces a bucket decision.
+            LogicalPlan::Scan(_)
+            | LogicalPlan::Filter(_)
+            | LogicalPlan::Join(_)
+            | LogicalPlan::Aggregate(_)
+            | LogicalPlan::Projection(_)
+            | LogicalPlan::Sort(_)
+            | LogicalPlan::SetOp(_)
+            | LogicalPlan::SubqueryAlias(_)
+            | LogicalPlan::TableFunction(_)
+            | LogicalPlan::With(_)
+            | LogicalPlan::CteRef(_)
+            | LogicalPlan::Values(_)
+            | LogicalPlan::Empty => {}
+        }
+    }
+    Some(crud)
+}

--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -237,11 +237,15 @@ impl<'a> Binder<'a> {
     /// statement then binds to nothing, so an `UnsupportedStatement` (it
     /// projects to the table level) signals the empty surfaces are a coverage
     /// gap, not "nothing there". `message` shows the offending target.
-    pub(super) fn record_unsupported_dml_target(&mut self, statement: &str, factor: &TableFactor) {
+    pub(super) fn record_unsupported_dml_target(
+        &mut self,
+        statement: &str,
+        target: &dyn std::fmt::Display,
+    ) {
         self.diagnostics.push(ColumnLevelDiagnostic {
             kind: ColumnLevelDiagnosticKind::UnsupportedStatement,
             message: format!(
-                "{statement} target `{factor}` is not a plain table (a derived table / subquery / table function) — the statement can't be analyzed and is dropped"
+                "{statement} target `{target}` is not a writable base table (a CTE name, derived table, subquery, table function, or join) — the statement can't be analyzed and is dropped"
             ),
             span: None,
         });

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -741,11 +741,21 @@ impl<'a> Binder<'a> {
         exprs
             .iter()
             .map(|ne| {
+                // An identity output re-reads a real base column (so a later
+                // clause-alias / pipe reference to it reads that column). Only a
+                // `Base` column qualifies: a `Derived` passthrough (a pipe-
+                // carried alias, a derived-table column) traces back through the
+                // projection chain, not to a base table — marking it identity
+                // would let a later stage fall through to the base relation and
+                // fabricate a phantom read.
                 let identity = match &ne.expr {
-                    Expr::Column(c) => ne
-                        .name
-                        .as_ref()
-                        .is_some_and(|n| self.eq(self.style.casing.column, n, &c.name)),
+                    Expr::Column(c) => {
+                        matches!(c.binding, Binding::Base { .. })
+                            && ne
+                                .name
+                                .as_ref()
+                                .is_some_and(|n| self.eq(self.style.casing.column, n, &c.name))
+                    }
                     _ => false,
                 };
                 OutputCol {

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -569,7 +569,7 @@ impl<'a> Binder<'a> {
     /// known column list (a catalog-free table, an opaque table function)
     /// contributes nothing, so a catalog-free NATURAL join yields no merge
     /// columns (an unqualified reference stays ambiguous rather than fanning in).
-    fn natural_merge_columns(&self, left: &Scope, right: &Scope) -> Vec<Ident> {
+    pub(super) fn natural_merge_columns(&self, left: &Scope, right: &Scope) -> Vec<Ident> {
         let right_columns: Vec<&Ident> = right
             .relations
             .iter()

--- a/sql-insight/src/resolver/binder/resolve.rs
+++ b/sql-insight/src/resolver/binder/resolve.rs
@@ -280,11 +280,11 @@ impl<'a> Binder<'a> {
     /// hit. (The matched columns are quote-wrapped for case-folded resolution;
     /// the written column list takes the plain identifier.)
     pub(super) fn catalog_columns(&self, target: &TableReference) -> Vec<Ident> {
-        self.table_match(target)
-            .columns
-            .iter()
-            .map(|c| Ident::new(&c.value))
-            .collect()
+        // Keep each column in its canonical form (quoted as `canonical_quote`
+        // dictates), not re-wrapped as a plain identifier — so a column-less
+        // MERGE INSERT fills a case-exact column like `"MyCol"` quoted, matching
+        // the catalog (Cataloged) and a user's own quoted reference.
+        self.table_match(target).columns
     }
 
     pub(super) fn eq(&self, fold: CaseRule, a: &Ident, b: &Ident) -> bool {

--- a/sql-insight/src/resolver/binder/scope.rs
+++ b/sql-insight/src/resolver/binder/scope.rs
@@ -143,14 +143,19 @@ impl Scope {
         let alias_columns: Vec<&Ident> = alias
             .map(|a| a.columns.iter().map(|c| &c.name).collect())
             .unwrap_or_default();
-        self.query_outputs
-            .iter()
-            .enumerate()
-            .filter_map(|(i, o)| {
+        // An explicit column-alias list (`… AS d(x, y)`) declares the exposed
+        // columns by position; past it, the body's own output names apply. Drive
+        // by the longer of the two so the declared alias names survive even when
+        // the body exposes no names (a `SELECT *` whose outputs are unexpanded) —
+        // otherwise a reference to an aliased column would dangle as a phantom
+        // unresolved read instead of binding to this derived relation.
+        let len = alias_columns.len().max(self.query_outputs.len());
+        (0..len)
+            .filter_map(|i| {
                 alias_columns
                     .get(i)
                     .map(|n| (*n).clone())
-                    .or_else(|| o.name.clone())
+                    .or_else(|| self.query_outputs.get(i).and_then(|o| o.name.clone()))
             })
             .collect()
     }

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -369,10 +369,20 @@ impl<'a> Binder<'a> {
         };
         let mut scope = Scope::single(target_relation);
         let mut input = LogicalPlan::Empty;
-        // Joins on the UPDATE target clause are read relations.
+        // Joins on the UPDATE target clause are read relations. They fan in
+        // merge columns like a SELECT join (`bind_table_with_joins`): a `USING
+        // (col)` names them, a NATURAL join takes the schema-common columns —
+        // both computed before the right scope is absorbed — so an unqualified
+        // reference resolves to both sides instead of staying `Ambiguous`.
         for j in joins {
             let (node, jscope) = self.bind_table_factor(&j.relation, &scope.relations);
-            scope.relations.extend(jscope.relations);
+            let merge = if join_is_natural(&j.join_operator) {
+                self.natural_merge_columns(&scope, &jscope)
+            } else {
+                join_using(&j.join_operator)
+            };
+            scope.absorb(jscope);
+            scope.add_merge_columns(merge);
             let on = join_on(&j.join_operator)
                 .map(|e| self.bind_expr(e, &scope))
                 .into_iter()

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -112,6 +112,13 @@ impl<'a> Binder<'a> {
             return LogicalPlan::Empty;
         };
         let m = self.table_match(&written);
+        // The target is a real table, never a CTE (you can't INSERT into a
+        // read-only CTE): a name that matches a declared CTE and isn't a catalog
+        // table is the CTE — flag and drop rather than fabricate a write.
+        if m.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
+            self.record_unsupported_dml_target("INSERT", &written);
+            return LogicalPlan::Empty;
+        }
         let target = m.table;
         // MySQL `INSERT INTO t SET col = expr, …`: the assignment form (no
         // VALUES / SELECT source) — each assignment is a value column named by
@@ -348,13 +355,14 @@ impl<'a> Binder<'a> {
         let (target_factor, joins) = flatten_dml_target(&update.table);
         // The root's own resolution isn't needed here — each SET assignment
         // carries its write-target table's resolution (`assignment_target`).
+        let diagnostics_before = self.diagnostics.len();
         let Some((target_relation, target, _)) = self.target_relation(target_factor) else {
-            // A non-table target (derived table / subquery / table function)
-            // can't be a write target — flag it (like `bind_merge`) rather than
-            // dropping silently. A plain table that failed to resolve is already
-            // flagged by `table_ref` (e.g. too many qualifiers), so don't
-            // double-report it.
-            if !matches!(target_factor, TableFactor::Table { .. }) {
+            // A non-writable target (a CTE name, derived table, subquery, table
+            // function, or join) can't be a write target — flag it (like
+            // `bind_merge`) rather than dropping silently. A plain table that
+            // failed to resolve already flagged itself (e.g. `table_ref`'s too-
+            // many-qualifiers), so flag only when nothing was reported.
+            if self.diagnostics.len() == diagnostics_before {
                 self.record_unsupported_dml_target("UPDATE", target_factor);
             }
             return LogicalPlan::Empty;
@@ -513,12 +521,16 @@ impl<'a> Binder<'a> {
             self.record_unsupported_dml_target("MERGE", &merge.table);
             return LogicalPlan::Empty;
         }
+        let diagnostics_before = self.diagnostics.len();
         let Some((target_relation, target, target_resolution)) = self.target_relation(&merge.table)
         else {
-            // A non-table MERGE target (derived table / subquery / table
-            // function) can't be a write target — flag it rather than dropping
-            // the whole statement silently (best-effort drop + flag).
-            self.record_unsupported_dml_target("MERGE", &merge.table);
+            // A non-writable MERGE target (a CTE name, derived table, subquery,
+            // or table function) can't be a write target — flag it rather than
+            // dropping the whole statement silently. A name that flagged itself
+            // (e.g. too many qualifiers) isn't double-reported.
+            if self.diagnostics.len() == diagnostics_before {
+                self.record_unsupported_dml_target("MERGE", &merge.table);
+            }
             return LogicalPlan::Empty;
         };
         let mut scope = Scope::single(target_relation);
@@ -652,32 +664,92 @@ impl<'a> Binder<'a> {
         &mut self,
         factor: &TableFactor,
     ) -> Option<(Relation, TableReference, ResolutionKind)> {
-        // Reuse the table-factor binder for catalog matching / column
-        // knowledge; the target isn't read (it's named on the DML root), but
-        // the scan's `resolution` is the catalog match we keep for the write.
-        let (scan, scope) = self.bind_table_factor(factor, &[]);
-        let relation = scope.relations.into_iter().next()?;
-        match &relation {
-            Relation::Table { table, .. } => {
-                let resolution = match &scan {
-                    LogicalPlan::Scan(s) => s.resolution,
-                    _ => ResolutionKind::Inferred,
-                };
-                let target = table.clone();
-                Some((relation, target, resolution))
-            }
-            Relation::Derived { .. } | Relation::TableFunction { .. } => None,
+        // A DML target is a real table, never a CTE: a database resolves the
+        // target against the catalog, not the `WITH` list (a CTE is read-only —
+        // Postgres errors `relation "c" does not exist` for `WITH c … UPDATE c`,
+        // and updates the *base* table when one shares the CTE's name). So
+        // resolve a plain name CTE-blind via `bind_named_table` (which skips the
+        // `CteRef` shortcut `bind_table_factor` takes); a non-name factor
+        // (subquery / derived / join / table function) is never a writable
+        // table. Either way a non-table target returns `None` and the caller
+        // flags it.
+        let TableFactor::Table {
+            name,
+            alias,
+            args: None,
+            ..
+        } = factor
+        else {
+            return None;
+        };
+        // `table_ref` flags an over-qualified name (and returns `None`) itself.
+        let written = self.table_ref(name)?;
+        let m = self.table_match(&written);
+        // A name that matches a declared CTE and isn't a catalog table is the
+        // CTE, not a writable table — not a target.
+        if m.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
+            return None;
         }
+        let alias_name = alias.as_ref().map(|a| a.name.clone());
+        let (scan, scope) = self.bind_named_table(&written, alias_name);
+        let relation = scope.relations.into_iter().next()?;
+        let Relation::Table { table, .. } = &relation else {
+            return None;
+        };
+        let resolution = match &scan {
+            LogicalPlan::Scan(s) => s.resolution,
+            _ => ResolutionKind::Inferred,
+        };
+        let target = table.clone();
+        Some((relation, target, resolution))
+    }
+
+    /// Whether a bare (single-segment) target name matches a CTE declared in
+    /// scope — used to reject a DML target that names a CTE (a CTE is read-only,
+    /// never a writable table). Mirrors the CTE lookup `bind_table_factor` does
+    /// for a FROM reference, but here it gates flagging, not resolution.
+    pub(super) fn is_declared_cte(&self, written: &TableReference) -> bool {
+        written.schema.is_none()
+            && written.catalog.is_none()
+            && self
+                .context
+                .ctes
+                .iter()
+                .any(|c| self.eq(self.style.casing.table_alias, &c.name, &written.name))
     }
 
     /// The plain-table deletion targets of a FROM `TableWithJoins` (its
     /// relation plus any joined relations), catalog-canonicalised.
-    pub(super) fn twj_table_targets(&self, twj: &TableWithJoins) -> Vec<TableWrite> {
-        std::iter::once(&twj.relation)
+    pub(super) fn twj_table_targets(&mut self, twj: &TableWithJoins) -> Vec<TableWrite> {
+        let writtens: Vec<TableReference> = std::iter::once(&twj.relation)
             .chain(twj.joins.iter().map(|join| &join.relation))
             .filter_map(|factor| TableReference::try_from(factor).ok())
-            .map(|written| self.table_write(&written))
+            .collect();
+        writtens
+            .into_iter()
+            .filter_map(|written| self.writable_target("DELETE", &written))
             .collect()
+    }
+
+    /// Resolve a DML target *name* to its real-table [`TableWrite`], or `None`
+    /// (recording a diagnostic) when the name is a declared CTE rather than a
+    /// writable base table. A catalog match wins (a base table sharing the CTE's
+    /// name is the real target); an uncatalogued name that is *not* a CTE stays
+    /// an `Inferred` table (the usual catalog-free best effort).
+    pub(super) fn writable_target(
+        &mut self,
+        statement: &str,
+        written: &TableReference,
+    ) -> Option<TableWrite> {
+        let m = self.table_match(written);
+        if m.resolution != ResolutionKind::Cataloged && self.is_declared_cte(written) {
+            self.record_unsupported_dml_target(statement, written);
+            return None;
+        }
+        Some(TableWrite {
+            reference: m.table,
+            resolution: m.resolution,
+        })
     }
 
     /// Resolve an explicit `DELETE` target name to its real table: a
@@ -690,10 +762,10 @@ impl<'a> Binder<'a> {
         scope: &Scope,
     ) -> Option<TableWrite> {
         let written = self.table_ref(name)?;
-        Some(
-            self.scope_target(&written, scope)
-                .unwrap_or_else(|| self.table_write(&written)),
-        )
+        if let Some(target) = self.scope_target(&written, scope) {
+            return Some(target);
+        }
+        self.writable_target("DELETE", &written)
     }
 
     /// If a `written` DELETE-target name matches an in-scope real-table

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -142,12 +142,16 @@ impl<'a> Binder<'a> {
             .is_some_and(|q| source_has_wildcard(q));
         // The written column list: an explicit `(a, b)` wins; otherwise a
         // column-less INSERT fills from the target's catalog columns (reusing
-        // the `table_match` list above, plain identifiers), truncated to the
-        // source's projected arity. But a wildcard source has indeterminate
-        // arity — the `*` isn't in `query_outputs`, so the visible count is too
-        // low — and the catalog columns can't be positionally paired: leave the
-        // list empty so the drop + flag guard below fires rather than
-        // mis-truncating to the undercounted outputs.
+        // the `table_match` list above), truncated to the source's projected
+        // arity. The catalog columns are kept in their canonical form (quoted as
+        // `canonical_quote` dictates), not re-wrapped as plain identifiers — so a
+        // case-exact column like `"MyCol"` surfaces quoted and matches both the
+        // catalog (→ `Cataloged`, not `Inferred`) and a user's own quoted
+        // reference. But a wildcard source has indeterminate arity — the `*`
+        // isn't in `query_outputs`, so the visible count is too low — and the
+        // catalog columns can't be positionally paired: leave the list empty so
+        // the drop + flag guard below fires rather than mis-truncating to the
+        // undercounted outputs.
         let columns = if !insert.columns.is_empty() {
             insert.columns.clone()
         } else if source_wildcard {
@@ -156,7 +160,7 @@ impl<'a> Binder<'a> {
             m.columns
                 .iter()
                 .take(scope.query_outputs.len())
-                .map(|c| Ident::new(&c.value))
+                .cloned()
                 .collect()
         };
         // A column-list-less INSERT whose target columns can't be determined

--- a/sql-insight/src/resolver/lineage.rs
+++ b/sql-insight/src/resolver/lineage.rs
@@ -242,6 +242,24 @@ fn relation_lineage<'a>(
     context: &mut TraceContext<'a>,
     out: &mut Vec<ColumnLineageEdge>,
 ) {
+    // A VALUES source has no projection operand, so pair each row's value cells
+    // positionally with the target columns directly: a scalar subquery in a
+    // cell flows like an `INSERT … SELECT` value. Several rows each contribute,
+    // so a target column collects sources from every row (the leading `WITH` was
+    // already entered into `context` by the caller). Constant cells trace to no
+    // origin. Resolution-blind to row arity here — the arity check is separate.
+    if let LogicalPlan::Values(values) = input {
+        for row in &values.rows {
+            for (target_column, expr) in columns.iter().zip(row) {
+                emit_edges(
+                    origins_of_expr(expr, input, context),
+                    ColumnTarget::Relation(target_column.clone()),
+                    out,
+                );
+            }
+        }
+        return;
+    }
     for operand in output_operands(input) {
         let outputs = operand.outputs;
         operand.trace(context, |src_input, cx| {
@@ -591,8 +609,16 @@ fn feeding_scans<'a>(
                 feeding_scans(body, context, fed_ctes, out)
             });
         }
-        // A nested data-mover feeds through its source; DELETE / DROP / ALTER /
-        // VALUES move no row data into a feeding path.
+        // A VALUES source moves its row cells into the target: a value-position
+        // subquery in a cell feeds (a scalar `(SELECT … FROM s)`), mirroring the
+        // column-level relation lineage. Constant cells feed nothing.
+        LogicalPlan::Values(v) => {
+            for expr in v.rows.iter().flatten() {
+                expr_feeding(expr, context, fed_ctes, out);
+            }
+        }
+        // A nested data-mover feeds through its source; DELETE / DROP / ALTER
+        // move no row data into a feeding path.
         LogicalPlan::Insert(i) => feeding_scans(&i.input, context, fed_ctes, out),
         LogicalPlan::Update(u) => feeding_scans(&u.input, context, fed_ctes, out),
         LogicalPlan::CreateTableAs(c) => feeding_scans(&c.input, context, fed_ctes, out),
@@ -601,7 +627,6 @@ fn feeding_scans<'a>(
         LogicalPlan::Delete(_)
         | LogicalPlan::Drop(_)
         | LogicalPlan::AlterTable(_)
-        | LogicalPlan::Values(_)
         | LogicalPlan::Empty => {}
     }
 }

--- a/sql-insight/src/resolver/lineage.rs
+++ b/sql-insight/src/resolver/lineage.rs
@@ -11,7 +11,9 @@
 
 use sqlparser::ast::Ident;
 
-use super::logical_plan::{peel_with, Expr, LogicalPlan, MergeClause, NamedExpr, Update};
+use super::logical_plan::{
+    dml_roots, is_dml_root, peel_with, Expr, LogicalPlan, MergeClause, NamedExpr, Update,
+};
 use super::origins::{
     conflict_value_origins, enter_withs, origins_of_expr, output_operands, TraceContext,
 };
@@ -36,31 +38,61 @@ pub(super) fn collect_column_lineage(
 ) -> Vec<ColumnLineageEdge> {
     let mut context = TraceContext::new(plan, casing);
     let mut edges = Vec::new();
-    match peel_with(plan) {
+    // Each DML root — the outer root and every data-modifying CTE body
+    // (`WITH c AS (INSERT … RETURNING …) …`) — pairs its source with its write
+    // target (`Relation` edges). Only the outer root's RETURNING is a statement
+    // output (`QueryOutput`); a CTE body's RETURNING feeds the CTE, consumed by
+    // the outer query, so it is not emitted as a statement output.
+    let outer = peel_with(plan);
+    for root in dml_roots(plan) {
+        dml_relation_lineage(root, std::ptr::eq(root, outer), &mut context, &mut edges);
+    }
+    // A read-only outer body additionally emits its `QueryOutput` edges (a DML
+    // outer root's outputs are its target columns, already handled above).
+    if !is_dml_root(outer) {
+        query_output_lineage(plan, &mut context, &mut edges);
+    }
+    edges
+}
+
+/// The `source → Relation` column edges one DML / DDL write root emits — its
+/// write-target columns paired with the source. Read-only / structural nodes
+/// and pure row movers (DELETE without RETURNING, ALTER / DROP) emit none.
+/// `is_outer` gates the RETURNING projection: only the outer root's RETURNING is
+/// a statement `QueryOutput`; a data-modifying CTE body's is internal.
+fn dml_relation_lineage<'a>(
+    root: &'a LogicalPlan,
+    is_outer: bool,
+    context: &mut TraceContext<'a>,
+    edges: &mut Vec<ColumnLineageEdge>,
+) {
+    match root {
         // INSERT … <source>: pair the source's outputs with the target columns.
         // A statement-level `WITH` rides on the source (the parser attaches it
         // there, so the `With` is *inside* `input`, not above the `Insert`);
         // `enter_withs` pushes its CTEs into the context so a `CteRef` resolves.
         LogicalPlan::Insert(i) => {
-            let src = enter_withs(&i.input, &mut context);
+            let src = enter_withs(&i.input, context);
             // A wildcard in the source projection makes positions indeterminate,
             // so positional pairing would mis-attribute (`SELECT *, y` → which
             // target does `y` feed?). Drop the relation lineage — the target
             // columns still surface as `writes`, flagged by `WildcardSuppressed`
             // — matching a pure `SELECT *` source (no operands to pair).
             if !i.source_wildcard {
-                relation_lineage(&i.columns, src, &mut context, &mut edges);
+                relation_lineage(&i.columns, src, context, edges);
             }
             // ON CONFLICT DO UPDATE SET col = value: each `value → target.col`,
             // an `EXCLUDED.x` ref mapped to the source's like-positioned output.
             for a in &i.on_conflict {
                 emit_edges(
-                    conflict_value_origins(&a.value, &i.columns, src, &mut context),
+                    conflict_value_origins(&a.value, &i.columns, src, context),
                     ColumnTarget::Relation(a.target.clone()),
-                    &mut edges,
+                    edges,
                 );
             }
-            returning_lineage(&i.returning, &i.input, &mut context, &mut edges);
+            if is_outer {
+                returning_lineage(&i.returning, &i.input, context, edges);
+            }
         }
         // UPDATE … SET col = expr: each assignment's RHS value traces to its
         // target column (`Relation` edge). A `Derived` RHS ref (a column of a
@@ -68,44 +100,36 @@ pub(super) fn collect_column_lineage(
         LogicalPlan::Update(u) => {
             for a in &u.assignments {
                 emit_edges(
-                    origins_of_expr(&a.value, &u.input, &mut context),
+                    origins_of_expr(&a.value, &u.input, context),
                     ColumnTarget::Relation(a.target.clone()),
-                    &mut edges,
+                    edges,
                 );
             }
-            returning_lineage(&u.returning, &u.input, &mut context, &mut edges);
+            if is_outer {
+                returning_lineage(&u.returning, &u.input, context, edges);
+            }
         }
         // DELETE moves no data (rows go wholesale) — its only lineage is a
-        // RETURNING projection of the deleted rows.
+        // RETURNING projection of the deleted rows (a statement-level output).
         LogicalPlan::Delete(d) => {
-            returning_lineage(&d.returning, &d.input, &mut context, &mut edges)
+            if is_outer {
+                returning_lineage(&d.returning, &d.input, context, edges);
+            }
         }
         // CTAS / CREATE VIEW move data like INSERT, but the new relation's
         // column *names* are the source outputs' own (unless an explicit list
         // overrides) — so pair each output with its own name, not a separately
         // derived list that could drift in length.
         LogicalPlan::CreateTableAs(c) => {
-            let src = enter_withs(&c.input, &mut context);
+            let src = enter_withs(&c.input, context);
             if pairs_positionally(c.source_wildcard, &c.columns) {
-                created_relation_lineage(
-                    &c.columns,
-                    &c.target.reference,
-                    src,
-                    &mut context,
-                    &mut edges,
-                );
+                created_relation_lineage(&c.columns, &c.target.reference, src, context, edges);
             }
         }
         LogicalPlan::CreateView(c) => {
-            let src = enter_withs(&c.input, &mut context);
+            let src = enter_withs(&c.input, context);
             if pairs_positionally(c.source_wildcard, &c.columns) {
-                created_relation_lineage(
-                    &c.columns,
-                    &c.target.reference,
-                    src,
-                    &mut context,
-                    &mut edges,
-                );
+                created_relation_lineage(&c.columns, &c.target.reference, src, context, edges);
             }
         }
         // MERGE: each WHEN action's value traces to its target column (an
@@ -117,18 +141,12 @@ pub(super) fn collect_column_lineage(
                 match clause {
                     MergeClause::Update { assignments } => {
                         for a in assignments {
-                            merge_value_edges(
-                                &a.target,
-                                &a.value,
-                                &m.source,
-                                &mut context,
-                                &mut edges,
-                            );
+                            merge_value_edges(&a.target, &a.value, &m.source, context, edges);
                         }
                     }
                     MergeClause::Insert { columns, values } => {
                         for (column, value) in columns.iter().zip(values) {
-                            merge_value_edges(column, value, &m.source, &mut context, &mut edges);
+                            merge_value_edges(column, value, &m.source, context, edges);
                         }
                     }
                     MergeClause::Delete => {}
@@ -136,12 +154,12 @@ pub(super) fn collect_column_lineage(
             }
             // RETURNING / OUTPUT projects the affected rows (target + source),
             // traced through the source like the other DMLs' RETURNING.
-            returning_lineage(&m.returning, &m.source, &mut context, &mut edges);
+            if is_outer {
+                returning_lineage(&m.returning, &m.source, context, edges);
+            }
         }
-        // A bare query (or unmodelled root): one `QueryOutput` group per
-        // projection (a set operation has one per branch — positions restart
-        // per branch, mirroring the resolver). DDL that names a table but
-        // moves no value (`AlterTable` / `Drop`) flows here too — it emits no
+        // Read-only / structural nodes are not write roots, and DDL that names a
+        // table but moves no value (`AlterTable` / `Drop`) emits no relation
         // lineage. Listed explicitly so a new `LogicalPlan` variant forces a
         // routing decision rather than landing here by default.
         LogicalPlan::Scan(_)
@@ -158,9 +176,8 @@ pub(super) fn collect_column_lineage(
         | LogicalPlan::Values(_)
         | LogicalPlan::Empty
         | LogicalPlan::AlterTable(_)
-        | LogicalPlan::Drop(_) => query_output_lineage(plan, &mut context, &mut edges),
+        | LogicalPlan::Drop(_) => {}
     }
-    edges
 }
 
 /// Bare-query lineage: each output column becomes a `QueryOutput` target at
@@ -341,27 +358,42 @@ pub(super) fn collect_table_lineage(
     plan: &LogicalPlan,
     casing: IdentifierCasing,
 ) -> Vec<TableLineageEdge> {
-    // `TraceContext::new` peels leading WITHs and keeps their CTE bodies, so a `CteRef`
-    // on the feeding path resolves to the body's feeding scans. `fed_ctes`
-    // is the set of CTE bodies already fed: a CTE body materializes once, so it feeds
-    // the target once regardless of how many `CteRef`s point at it. It keys on
-    // the resolved body's *identity* (its pointer), not the CTE name, so two
-    // distinct CTEs that happen to share a name (shadowing across scopes) each
-    // feed — a name key would collapse them. (The active-set on `context` terminates
-    // a *recursive* self-reference; this set folds *distinct* references to the
-    // *same* declaration — orthogonal concerns.)
+    // `TraceContext::new` peels leading WITHs and keeps their CTE bodies, so a
+    // `CteRef` on the feeding path resolves to the body's feeding scans. Each
+    // DML root — the outer root and every data-modifying CTE body — contributes
+    // its own `source → target` edges (a read-only outer body has none).
     let mut context = TraceContext::new(plan, casing);
+    dml_roots(plan)
+        .into_iter()
+        .flat_map(|root| dml_table_lineage(root, &mut context))
+        .collect()
+}
+
+/// The `source → target` table edges one DML root emits: its feeding sources
+/// paired with its write target. UPDATE fans per-assignment-target out of line.
+///
+/// `fed_ctes` is the set of CTE bodies already fed *this target*: a CTE body
+/// materializes once, so it feeds the target once regardless of how many
+/// `CteRef`s point at it. It keys on the resolved body's *identity* (its
+/// pointer), not the CTE name, so two distinct CTEs that happen to share a name
+/// (shadowing across scopes) each feed — a name key would collapse them. (The
+/// active-set on `context` terminates a *recursive* self-reference; this set
+/// folds *distinct* references to the *same* declaration — orthogonal concerns.)
+fn dml_table_lineage<'a>(
+    root: &'a LogicalPlan,
+    context: &mut TraceContext<'a>,
+) -> Vec<TableLineageEdge> {
     let mut sources = Vec::new();
     let mut fed_ctes: Vec<usize> = Vec::new();
-    let target = match peel_with(plan) {
+    let target = match root {
         LogicalPlan::Insert(i) => {
-            feeding_scans(&i.input, &mut context, &mut fed_ctes, &mut sources);
+            feeding_scans(&i.input, context, &mut fed_ctes, &mut sources);
             // ON CONFLICT DO UPDATE SET col = value: a value-position subquery
             // (`= (SELECT … FROM other)`) feeds the target, like an UPDATE SET
             // RHS. An `EXCLUDED.x` ref feeds nothing new — it names the INSERT
             // source row, already collected from `i.input`.
             for a in &i.on_conflict {
-                expr_feeding(&a.value, &mut context, &mut fed_ctes, &mut sources);
+                expr_feeding(&a.value, context, &mut fed_ctes, &mut sources);
             }
             &i.target
         }
@@ -370,12 +402,12 @@ pub(super) fn collect_table_lineage(
         // `UPDATE t1 JOIN t2 SET t2.b = t1.c` writes t1.c into t2, not the root.
         // (Handled out of line since it has several targets, unlike the
         // single-target DML below.)
-        LogicalPlan::Update(u) => return update_table_lineage(u, &mut context),
+        LogicalPlan::Update(u) => return update_table_lineage(u, context),
         // CTAS / CREATE VIEW move data like INSERT; ALTER / DROP do not. A
         // `CLONE src` copies the data, so its shape source feeds `src → target`
         // (a `LIKE src` copies only the schema → no edge).
         LogicalPlan::CreateTableAs(c) => {
-            feeding_scans(&c.input, &mut context, &mut fed_ctes, &mut sources);
+            feeding_scans(&c.input, context, &mut fed_ctes, &mut sources);
             if let Some(schema_source) = &c.schema_source {
                 if schema_source.copies_data {
                     sources.push(schema_source.source.clone());
@@ -384,24 +416,34 @@ pub(super) fn collect_table_lineage(
             &c.target
         }
         LogicalPlan::CreateView(c) => {
-            feeding_scans(&c.input, &mut context, &mut fed_ctes, &mut sources);
+            feeding_scans(&c.input, context, &mut fed_ctes, &mut sources);
             &c.target
         }
         // MERGE feeds from the source relation plus each *written* WHEN value
         // (an UPDATE SET RHS; an INSERT value paired with a column). The ON /
-        // predicate reads and an unpaired INSERT value do not feed.
+        // predicate reads and an unpaired INSERT value do not feed. A MERGE
+        // whose clauses are *only* DELETEs moves no data — its source picks
+        // target rows but feeds nothing — so don't feed the source then. (For a
+        // non-CTE root the lineage gate already skips this; the self-check also
+        // covers a data-modifying-CTE statement, which bypasses that gate.)
         LogicalPlan::Merge(m) => {
-            feeding_scans(&m.source, &mut context, &mut fed_ctes, &mut sources);
+            let writes_data = m
+                .clauses
+                .iter()
+                .any(|c| matches!(c, MergeClause::Insert { .. } | MergeClause::Update { .. }));
+            if writes_data {
+                feeding_scans(&m.source, context, &mut fed_ctes, &mut sources);
+            }
             for clause in &m.clauses {
                 match clause {
                     MergeClause::Update { assignments } => {
                         for a in assignments {
-                            expr_feeding(&a.value, &mut context, &mut fed_ctes, &mut sources);
+                            expr_feeding(&a.value, context, &mut fed_ctes, &mut sources);
                         }
                     }
                     MergeClause::Insert { columns, values } => {
                         for (_col, value) in columns.iter().zip(values) {
-                            expr_feeding(value, &mut context, &mut fed_ctes, &mut sources);
+                            expr_feeding(value, context, &mut fed_ctes, &mut sources);
                         }
                     }
                     MergeClause::Delete => {}
@@ -409,10 +451,10 @@ pub(super) fn collect_table_lineage(
             }
             &m.target
         }
-        // No table lineage: a bare query (no target), DDL that moves no value
-        // (`Drop` / `Truncate` modelled as `Drop` / `AlterTable`), and the
-        // structural / synthetic operators reached at root. Listed explicitly
-        // so a new `LogicalPlan` variant forces a target decision.
+        // No table lineage: a bare query / read root (no target), DELETE (rows
+        // go wholesale, no value moved), and DDL that moves no value (`Drop` /
+        // `Truncate` modelled as `Drop` / `AlterTable`). Listed explicitly so a
+        // new `LogicalPlan` variant forces a target decision.
         LogicalPlan::Scan(_)
         | LogicalPlan::Filter(_)
         | LogicalPlan::Join(_)

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -688,6 +688,69 @@ pub(super) fn peel_with(op: &LogicalPlan) -> &LogicalPlan {
     node
 }
 
+/// Every DML / DDL write **root** a statement carries: the peeled outer root,
+/// plus each *data-modifying* CTE body (`WITH c AS (INSERT … RETURNING …) …`) —
+/// recursively, so multiple sibling and nested data-modifying CTEs are all
+/// collected. A read-only body / CTE contributes nothing. Backs the write /
+/// CRUD / lineage walkers, since one statement can have more than one write
+/// root. (A data-modifying CTE nested inside another root's *source* query is
+/// not reached — only CTE declarations are descended, like the binder's shape.)
+pub(super) fn dml_roots(op: &LogicalPlan) -> Vec<&LogicalPlan> {
+    let mut out = Vec::new();
+    collect_dml_roots(op, &mut out);
+    out
+}
+
+/// Whether a node is a DML / DDL write root (the variants [`dml_roots`]
+/// collects) — used to tell a read-only outer body (which emits `QueryOutput`
+/// lineage) from a write root (which emits target lineage).
+pub(super) fn is_dml_root(op: &LogicalPlan) -> bool {
+    matches!(
+        op,
+        LogicalPlan::Insert(_)
+            | LogicalPlan::Update(_)
+            | LogicalPlan::Delete(_)
+            | LogicalPlan::Merge(_)
+            | LogicalPlan::CreateTableAs(_)
+            | LogicalPlan::CreateView(_)
+            | LogicalPlan::AlterTable(_)
+            | LogicalPlan::Drop(_)
+    )
+}
+
+fn collect_dml_roots<'a>(op: &'a LogicalPlan, out: &mut Vec<&'a LogicalPlan>) {
+    match op {
+        LogicalPlan::With(w) => {
+            for cte in &w.ctes {
+                collect_dml_roots(&cte.body, out);
+            }
+            collect_dml_roots(&w.body, out);
+        }
+        LogicalPlan::Insert(_)
+        | LogicalPlan::Update(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Merge(_)
+        | LogicalPlan::CreateTableAs(_)
+        | LogicalPlan::CreateView(_)
+        | LogicalPlan::AlterTable(_)
+        | LogicalPlan::Drop(_) => out.push(op),
+        // Read-only / structural roots write nothing — listed explicitly so a
+        // new `LogicalPlan` variant forces a write-root decision here.
+        LogicalPlan::Scan(_)
+        | LogicalPlan::Filter(_)
+        | LogicalPlan::Join(_)
+        | LogicalPlan::Aggregate(_)
+        | LogicalPlan::Projection(_)
+        | LogicalPlan::Sort(_)
+        | LogicalPlan::SetOp(_)
+        | LogicalPlan::SubqueryAlias(_)
+        | LogicalPlan::TableFunction(_)
+        | LogicalPlan::CteRef(_)
+        | LogicalPlan::Values(_)
+        | LogicalPlan::Empty => {}
+    }
+}
+
 /// Pre-order walk of the structural tree — structural children, the sub-plans
 /// nested in this node's own expressions (a `WHERE … IN (SELECT …)` / scalar
 /// subquery), and on a `With` each declared CTE body — invoking `f` at every

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -424,10 +424,14 @@ impl Expr {
                 v
             }
             Expr::Window { arg, .. } => vec![arg],
+            // `a IN (subquery)`: the LHS is a value operand — the IN result is a
+            // boolean transformation of it (`origins_of_expr` traces it the same
+            // way). The subquery side is the membership test, a filter
+            // (`filter_subplans`).
+            Expr::InSubquery { expr, .. } => vec![expr],
             Expr::Column(_)
             | Expr::Subquery { .. }
             | Expr::Exists(_)
-            | Expr::InSubquery { .. }
             | Expr::Filter(_)
             | Expr::Fanin(_) => Vec::new(),
         }
@@ -440,12 +444,12 @@ impl Expr {
             Expr::Window {
                 partition, order, ..
             } => partition.iter().chain(order).collect(),
-            Expr::InSubquery { expr, .. } => vec![expr],
             Expr::Filter(exprs) => exprs.iter().collect(),
             Expr::Column(_)
             | Expr::Call { .. }
             | Expr::Subquery { .. }
             | Expr::Exists(_)
+            | Expr::InSubquery { .. }
             | Expr::Fanin(_) => Vec::new(),
         }
     }

--- a/sql-insight/src/resolver/reads.rs
+++ b/sql-insight/src/resolver/reads.rs
@@ -61,9 +61,14 @@ pub(super) fn collect_table_reads(plan: &LogicalPlan) -> Vec<TableRead> {
         _ => {}
     });
     // A relation referenced by a column read but not itself scanned — the DML
-    // root, whose own data is consumed (the only non-`Scan` relation a base
-    // column can resolve to). Added once, its table-level resolution mirroring
-    // the column's.
+    // root (sink), whose own data is consumed (the only non-`Scan` relation a
+    // base column can resolve to). Added once, with the *table-level* catalog
+    // match as its resolution (mirroring its `TableWrite`), not the first hitting
+    // column's — a column's resolution reflects whether that *column* is
+    // cataloged (so it varies with which columns are referenced, and in which
+    // order), whereas the sink read should reflect whether the *table* is, like
+    // the write side.
+    let writes = super::tables::collect_table_writes(plan);
     for read in collect_reads(plan) {
         let Some(table) = &read.reference.table else {
             continue;
@@ -71,9 +76,14 @@ pub(super) fn collect_table_reads(plan: &LogicalPlan) -> Vec<TableRead> {
         if out.iter().any(|r| &r.reference == table) {
             continue;
         }
+        let resolution = writes
+            .iter()
+            .find(|w| &w.reference == table)
+            .map(|w| w.resolution)
+            .unwrap_or(read.resolution);
         out.push(TableRead {
             reference: table.clone(),
-            resolution: read.resolution,
+            resolution,
         });
     }
     out

--- a/sql-insight/src/resolver/tables.rs
+++ b/sql-insight/src/resolver/tables.rs
@@ -9,17 +9,26 @@
 
 use sqlparser::ast::Ident;
 
-use super::logical_plan::{peel_with, LogicalPlan, MergeClause};
+use super::logical_plan::{dml_roots, LogicalPlan, MergeClause};
 use super::origins::output_operands;
 use crate::reference::{ColumnReference, ColumnWrite, ResolutionKind, TableReference, TableWrite};
 
 // ===== writes ============================================================
 
-/// Every column the statement writes — a DML root's target columns, qualified
-/// by the write target. Order follows source order (the public contract). A
-/// leading `WITH` is peeled. Backs [`crate::resolver::writes`].
+/// Every column the statement writes — each DML root's target columns,
+/// qualified by the write target. Order follows source order (the public
+/// contract). Collects from the peeled outer root *and* every data-modifying
+/// CTE body (`WITH c AS (INSERT …) …`). Backs [`crate::resolver::writes`].
 pub(super) fn collect_writes(plan: &LogicalPlan) -> Vec<ColumnWrite> {
-    match peel_with(plan) {
+    dml_roots(plan)
+        .into_iter()
+        .flat_map(write_root_columns)
+        .collect()
+}
+
+/// The columns one DML / DDL write root targets.
+fn write_root_columns(root: &LogicalPlan) -> Vec<ColumnWrite> {
+    match root {
         // INSERT columns (already catalog-resolved), then any ON CONFLICT DO
         // UPDATE SET targets (extra writes on the same relation).
         LogicalPlan::Insert(i) => {
@@ -83,10 +92,19 @@ fn merge_clause_writes(clause: &MergeClause) -> Vec<ColumnWrite> {
     }
 }
 
-/// Every table the statement writes to — one per DML target. A leading `WITH`
-/// is peeled. Backs [`crate::resolver::table_writes`].
+/// Every table the statement writes to — one per DML target, across the peeled
+/// outer root and every data-modifying CTE body. Backs
+/// [`crate::resolver::table_writes`].
 pub(super) fn collect_table_writes(plan: &LogicalPlan) -> Vec<TableWrite> {
-    match peel_with(plan) {
+    dml_roots(plan)
+        .into_iter()
+        .flat_map(write_root_tables)
+        .collect()
+}
+
+/// The table(s) one DML / DDL write root targets.
+pub(super) fn write_root_tables(root: &LogicalPlan) -> Vec<TableWrite> {
+    match root {
         LogicalPlan::Insert(i) => vec![i.target.clone()],
         // The distinct tables the SET assignments write — the root for a
         // single-table UPDATE, but each qualified relation for a multi-table

--- a/sql-insight/src/resolver/tables.rs
+++ b/sql-insight/src/resolver/tables.rs
@@ -81,13 +81,12 @@ fn merge_clause_writes(clause: &MergeClause) -> Vec<ColumnWrite> {
         MergeClause::Update { assignments } => {
             assignments.iter().map(|a| a.target.clone()).collect()
         }
-        // Only columns paired with a value are written (a column-less / short
-        // INSERT writes nothing; `zip` stops at the shorter side).
-        MergeClause::Insert { columns, values } => columns
-            .iter()
-            .zip(values)
-            .map(|(cw, _)| cw.clone())
-            .collect(),
+        // Every named target column is a write, regardless of how many values
+        // are supplied (an arity mismatch is flagged separately) — matching a
+        // plain INSERT. A column-less MERGE INSERT has no names here, so it
+        // writes nothing. (Lineage, which *pairs* a column with its value, zips
+        // to the shorter side on its own path.)
+        MergeClause::Insert { columns, .. } => columns.clone(),
         MergeClause::Delete => Vec::new(),
     }
 }

--- a/sql-insight/tests/catalog.rs
+++ b/sql-insight/tests/catalog.rs
@@ -437,6 +437,42 @@ fn dml_target_resolves_to_the_base_table_not_a_shadowing_cte() {
 }
 
 #[test]
+fn from_ddl_skips_a_table_with_a_non_identifier_name_segment() {
+    // A name segment that isn't a plain identifier (Snowflake `IDENTIFIER('t')`)
+    // makes the table's identity unrepresentable — the whole CREATE is skipped,
+    // not mis-segmented into a phantom (`myschema.IDENTIFIER('t')` must not
+    // register as table `myschema`). A valid CREATE in the same DDL still
+    // registers.
+    use sql_insight::sqlparser::dialect::SnowflakeDialect;
+    let catalog = Catalog::from_ddl(
+        &SnowflakeDialect {},
+        "CREATE TABLE myschema.IDENTIFIER('t') (id INT); CREATE TABLE good (a INT)",
+    )
+    .unwrap();
+    let resolution = |sql: &str| -> ResolutionKind {
+        extract_column_operations_with_options(
+            &SnowflakeDialect {},
+            sql,
+            ExtractorOptions::new().with_catalog(&catalog),
+        )
+        .unwrap()
+        .remove(0)
+        .unwrap()
+        .reads
+        .first()
+        .unwrap()
+        .resolution
+    };
+    // The mis-segmented `myschema` phantom is not registered.
+    assert_eq!(
+        resolution("SELECT id FROM myschema"),
+        ResolutionKind::Inferred
+    );
+    // The valid sibling table still registers (the skip is per-statement).
+    assert_eq!(resolution("SELECT a FROM good"), ResolutionKind::Cataloged);
+}
+
+#[test]
 fn from_ddl_unquoted_registration_canonicalizes_the_surfaced_identity() {
     // The Cataloged read surfaces the catalog's stored (folded) identity, not
     // the query's written casing.

--- a/sql-insight/tests/catalog.rs
+++ b/sql-insight/tests/catalog.rs
@@ -416,6 +416,27 @@ fn from_ddl_with_casing_aligns_the_catalog_with_a_casing_override() {
 }
 
 #[test]
+fn dml_target_resolves_to_the_base_table_not_a_shadowing_cte() {
+    // A DML target name is resolved against the catalog, never the WITH list: a
+    // base table sharing a CTE's name is the real (Cataloged) write target,
+    // mirroring Postgres (which updates the base table, ignoring the CTE; only a
+    // CTE-*only* name errors / is flagged).
+    let catalog = Catalog::from_ddl(&GenericDialect {}, "CREATE TABLE c (x INT)").unwrap();
+    let op = extract_column_operations_with_options(
+        &GenericDialect {},
+        "WITH c AS (SELECT 1 AS x) UPDATE c SET x = 1",
+        ExtractorOptions::new().with_catalog(&catalog),
+    )
+    .unwrap()
+    .remove(0)
+    .unwrap();
+    assert_eq!(op.diagnostics, vec![]);
+    assert_eq!(op.writes.len(), 1);
+    assert_eq!(op.writes[0].resolution, ResolutionKind::Cataloged);
+    assert_eq!(op.writes[0].reference.name.value, "x");
+}
+
+#[test]
 fn from_ddl_unquoted_registration_canonicalizes_the_surfaced_identity() {
     // The Cataloged read surfaces the catalog's stored (folded) identity, not
     // the query's written casing.

--- a/sql-insight/tests/catalog.rs
+++ b/sql-insight/tests/catalog.rs
@@ -437,6 +437,29 @@ fn dml_target_resolves_to_the_base_table_not_a_shadowing_cte() {
 }
 
 #[test]
+fn column_less_insert_fills_a_case_exact_column_quoted_and_cataloged() {
+    // A column-less INSERT fills its column list from the catalog in the
+    // canonical (quoted) form — like the table — so a case-exact column matches
+    // the catalog (Cataloged, not Inferred) and a user's own `"MyCol"`
+    // reference. The filled name previously surfaced unquoted and missed.
+    use sql_insight::sqlparser::dialect::SnowflakeDialect;
+    let catalog =
+        Catalog::from_ddl(&SnowflakeDialect {}, r#"CREATE TABLE t ("MyCol" INT)"#).unwrap();
+    let op = extract_column_operations_with_options(
+        &SnowflakeDialect {},
+        "INSERT INTO t SELECT 1",
+        ExtractorOptions::new().with_catalog(&catalog),
+    )
+    .unwrap()
+    .remove(0)
+    .unwrap();
+    assert_eq!(op.writes.len(), 1);
+    assert_eq!(op.writes[0].reference.name.value, "MyCol");
+    assert_eq!(op.writes[0].reference.name.quote_style, Some('"'));
+    assert_eq!(op.writes[0].resolution, ResolutionKind::Cataloged);
+}
+
+#[test]
 fn from_ddl_skips_a_table_with_a_non_identifier_name_segment() {
     // A name segment that isn't a plain identifier (Snowflake `IDENTIFIER('t')`)
     // makes the table's identity unrepresentable — the whole CREATE is skipped,

--- a/sql-insight/tests/column_operation_extractor/arm_coverage.rs
+++ b/sql-insight/tests/column_operation_extractor/arm_coverage.rs
@@ -337,6 +337,46 @@ mod expr_arm_coverage {
     }
 
     #[test]
+    fn pipe_later_stage_ref_to_a_computed_column_is_not_a_base_read() {
+        // `SELECT a + b AS s` makes `s` a computed (Derived) output. A later
+        // stage referencing `s` traces back through the projection (a → s, b → s)
+        // — it must not fall through to a phantom `t.s` base read. (The Derived
+        // passthrough was wrongly marked an identity output, so the next stage
+        // resolved `s` against the still-in-scope base table.)
+        assert_column_ops(
+            "FROM t |> SELECT a + b AS s |> SELECT s |> WHERE s > 0",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("t", "a"), out("s", 0)),
+                    transformation(col("t", "b"), out("s", 0)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn pipe_renamed_column_carried_through_extend_traces_the_rename() {
+        // A renamed column (`a AS x`) carried through an EXTEND stage stays
+        // Derived: the final `SELECT x` traces `t.a -> x`, not a phantom
+        // `t.x -> x` (the rename was lost when the carried column was marked an
+        // identity output).
+        assert_column_ops(
+            "FROM t |> SELECT a AS x |> EXTEND 1 AS y |> SELECT x",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("x", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn pipe_pivot() {
         // The pivot's aggregate (`SUM(x)`) and value-source column (`k`) are
         // reads; `x` also appears in the projection.

--- a/sql-insight/tests/column_operation_extractor/arm_coverage.rs
+++ b/sql-insight/tests/column_operation_extractor/arm_coverage.rs
@@ -888,6 +888,24 @@ mod relation_arm_coverage {
     }
 
     #[test]
+    fn alias_columns_over_wildcard_body_bind_to_the_derived_relation() {
+        // A derived table / CTE whose body is `SELECT *` but which declares its
+        // columns via an alias list: a reference to a declared column binds to
+        // the derived relation (a `Derived` column → dropped from reads), not a
+        // phantom unresolved read. The wildcard's incompleteness is flagged
+        // separately (`WildcardSuppressed`), and the alias list is authoritative
+        // — a column *not* in it stays unresolved.
+        assert_unordered_eq!(
+            reads("SELECT x.c1 FROM (SELECT * FROM t) x (c1)"),
+            Vec::new()
+        );
+        assert_unordered_eq!(
+            reads("WITH cte (c1) AS (SELECT * FROM t) SELECT c1 FROM cte"),
+            Vec::new()
+        );
+    }
+
+    #[test]
     fn pipe_union_branch_reads_surface() {
         // A `|> UNION ALL (subquery)` pipe: the branch query's reads surface
         // (modelled as a filter-position subquery) alongside the input's.

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -1092,3 +1092,83 @@ mod alter_table {
         );
     }
 }
+
+mod data_modifying_cte {
+    //! A data-modifying CTE (Postgres `WITH c AS (INSERT / UPDATE / DELETE …
+    //! [RETURNING …]) …`) is a write root *inside* the WITH, even when the outer
+    //! statement is a read `SELECT`. Its writes / lineage surface like a
+    //! top-level DML — previously the walkers peeled to the outer body and
+    //! dropped them, mis-reporting the statement as read-only.
+    //!
+    //! Known limit: tracing a value *through* such a CTE's `RETURNING` columns
+    //! is best-effort. The CTE's own data-flow (`source → target`) is captured,
+    //! but a consumer of its `RETURNING` (the outer query, or a later CTE that
+    //! reads it) follows the `CteRef` to the body's *input* scans rather than
+    //! its write target — so the outer output column stays `Unresolved`. The
+    //! writes / table-writes / CRUD effects are exact regardless.
+    use super::*;
+
+    #[test]
+    fn insert_cte_writes_and_flows_to_its_target() {
+        assert_column_ops(
+            "WITH c AS (INSERT INTO x (a) SELECT v FROM s) SELECT 1 AS one",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("s", "v")],
+                writes: vec![write("x", "a")],
+                lineage: vec![passthrough(col("s", "v"), relation("x", "a"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn update_cte_writes_and_flows_to_its_target() {
+        assert_column_ops(
+            "WITH c AS (UPDATE z SET a = b + 1) SELECT 1 AS one",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("z", "b")],
+                writes: vec![write("z", "a")],
+                lineage: vec![transformation(col("z", "b"), relation("z", "a"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn delete_cte_reads_its_predicate_and_writes_no_columns() {
+        // DELETE removes whole rows: the predicate column is a read, but there
+        // are no column-level writes and no lineage.
+        assert_column_ops(
+            "WITH c AS (DELETE FROM y WHERE k = 1) SELECT 1 AS one",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("y", "k")],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn multiple_data_modifying_ctes_each_surface() {
+        // Two sibling data-modifying CTEs both contribute their writes / lineage.
+        assert_column_ops(
+            "WITH a AS (INSERT INTO x (c1) SELECT v FROM s), \
+                  b AS (UPDATE z SET d = e + 1) \
+             SELECT 1 AS one",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("s", "v"), read("z", "e")],
+                writes: vec![write("x", "c1"), write("z", "d")],
+                lineage: vec![
+                    passthrough(col("s", "v"), relation("x", "c1")),
+                    transformation(col("z", "e"), relation("z", "d")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -154,8 +154,10 @@ mod merge {
 
     #[test]
     fn merge_insert_arity_mismatch_is_flagged() {
-        // 3 target columns, 2 values: the surplus column is dropped (no value to
-        // pair with), flagged like a plain INSERT arity mismatch.
+        // 3 target columns, 2 values: every *named* target column is a write
+        // (`t.c` too — a named insert target is written regardless of value
+        // count, like a plain INSERT), flagged for the arity mismatch. Lineage
+        // only pairs the columns that have a value (`s.x → t.a`, `s.y → t.b`).
         assert_column_ops(
             "MERGE INTO t USING s ON t.id = s.id \
              WHEN NOT MATCHED THEN INSERT (a, b, c) VALUES (s.x, s.y)",
@@ -167,7 +169,7 @@ mod merge {
                     read("s", "x"),
                     read("s", "y"),
                 ],
-                writes: vec![write("t", "a"), write("t", "b")],
+                writes: vec![write("t", "a"), write("t", "b"), write("t", "c")],
                 lineage: vec![
                     passthrough(col("s", "x"), relation("t", "a")),
                     passthrough(col("s", "y"), relation("t", "b")),

--- a/sql-insight/tests/column_operation_extractor/diagnostics.rs
+++ b/sql-insight/tests/column_operation_extractor/diagnostics.rs
@@ -51,6 +51,76 @@ mod reported {
         );
     }
 
+    /// A DML target *name* that matches a declared CTE is the CTE, not a
+    /// writable table — a CTE is read-only. A database resolves the target
+    /// against the catalog, not the WITH list (Postgres errors `relation "c"
+    /// does not exist`, and updates the *base* table when one shares the name).
+    /// Catalog-free, all four DML flag it and drop, consistently — neither
+    /// fabricating a write (INSERT used to surface `c.x`) nor dropping silently
+    /// (UPDATE / DELETE used to).
+    fn assert_cte_target_flagged(sql: &str, kind: StatementKind) {
+        assert_column_ops(
+            sql,
+            ColumnOperation {
+                statement_kind: kind,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn insert_into_a_cte_name_reports_diagnostic() {
+        assert_cte_target_flagged(
+            "WITH c AS (SELECT 1 AS x) INSERT INTO c (x) VALUES (1)",
+            StatementKind::Insert,
+        );
+    }
+
+    #[test]
+    fn update_a_cte_name_reports_diagnostic() {
+        assert_cte_target_flagged(
+            "WITH c AS (SELECT 1 AS x) UPDATE c SET x = 1",
+            StatementKind::Update,
+        );
+    }
+
+    #[test]
+    fn delete_from_a_cte_name_reports_diagnostic() {
+        assert_cte_target_flagged(
+            "WITH c AS (SELECT 1 AS x) DELETE FROM c WHERE x = 1",
+            StatementKind::Delete,
+        );
+    }
+
+    #[test]
+    fn merge_into_a_cte_name_reports_diagnostic() {
+        assert_cte_target_flagged(
+            "WITH c AS (SELECT 1 AS x) MERGE INTO c USING s ON c.x = s.x \
+             WHEN MATCHED THEN UPDATE SET x = 1",
+            StatementKind::Merge,
+        );
+    }
+
+    #[test]
+    fn data_modifying_cte_survives_a_flagged_cte_target_update() {
+        // A *valid* data-modifying CTE (`d` inserts into `x`) and an *invalid*
+        // CTE-target UPDATE (`c` is read-only) compose: the real write is still
+        // surfaced, and only the bad target is flagged.
+        assert_column_ops(
+            "WITH d AS (INSERT INTO x (a) VALUES (1)), c AS (SELECT 1 AS y) UPDATE c SET y = 1",
+            ColumnOperation {
+                statement_kind: StatementKind::Update,
+                reads: vec![],
+                writes: vec![write("x", "a")],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
     #[test]
     fn over_qualified_read_table_reports_diagnostic() {
         // A FROM table with more than `catalog.schema.name` segments can't

--- a/sql-insight/tests/column_operation_extractor/joins_sets.rs
+++ b/sql-insight/tests/column_operation_extractor/joins_sets.rs
@@ -499,6 +499,27 @@ mod join_using_and_natural {
     }
 
     #[test]
+    fn update_join_using_column_fans_in_to_the_set_target() {
+        // The UPDATE target-clause join fans in its USING merge column like a
+        // SELECT join: the unqualified `id` resolves to both joined tables
+        // (t1.id + t2.id), each a read and a lineage source into the SET target
+        // — not a single ambiguous ref (the FROM-clause path already fanned in).
+        assert_column_ops(
+            "UPDATE t1 JOIN t2 USING (id) SET t2.a = id",
+            ColumnOperation {
+                statement_kind: StatementKind::Update,
+                reads: vec![read("t1", "id"), read("t2", "id")],
+                writes: vec![write("t2", "a")],
+                lineage: vec![
+                    passthrough(col("t1", "id"), relation("t2", "a")),
+                    passthrough(col("t2", "id"), relation("t2", "a")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn join_using_qualified_id_resolves_to_named_table() {
         // Qualifying the ref sidesteps the USING ambiguity: `t1.id`
         // resolves to t1 unambiguously. Use this in real-world

--- a/sql-insight/tests/column_operation_extractor/lineage.rs
+++ b/sql-insight/tests/column_operation_extractor/lineage.rs
@@ -67,6 +67,26 @@ mod projections {
     }
 
     #[test]
+    fn in_subquery_scalar_lhs_flows_to_the_target() {
+        // The LHS of `… IN (…)` in value position is a value source even when it
+        // is itself a scalar subquery: `s2.y` flows to the target `dst.f`. The
+        // membership subquery `s` stays a filter. (The table-lineage side used
+        // to classify the LHS as a filter, dropping `s2 -> dst` and
+        // contradicting this column edge — pinned together in the table-op
+        // suite.)
+        assert_column_ops(
+            "INSERT INTO dst (f) SELECT (SELECT y FROM s2) IN (SELECT x FROM s) FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s2", "y"), read("s", "x")],
+                writes: vec![write("dst", "f")],
+                lineage: vec![transformation(col("s2", "y"), relation("dst", "f"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn select_mixed_projection_separates_targets_by_position() {
         assert_column_ops(
             "SELECT a, a + b FROM t1",

--- a/sql-insight/tests/column_operation_extractor/lineage.rs
+++ b/sql-insight/tests/column_operation_extractor/lineage.rs
@@ -87,6 +87,43 @@ mod projections {
     }
 
     #[test]
+    fn values_scalar_subquery_flows_to_the_target() {
+        // A scalar subquery in a VALUES cell is a value source for its column,
+        // exactly like the equivalent `INSERT … SELECT` (previously dropped —
+        // the VALUES source produced no lineage).
+        assert_column_ops(
+            "INSERT INTO t (a) VALUES ((SELECT x FROM s))",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s", "x")],
+                writes: vec![write("t", "a")],
+                lineage: vec![transformation(col("s", "x"), relation("t", "a"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn multi_row_values_pair_each_row_with_the_target_columns() {
+        // Each row's cells pair positionally with the columns; a column collects
+        // sources from every row (col `a` ← row 2's `s2.y`, col `b` ← row 1's
+        // `s.x`). Constant cells trace to no source.
+        assert_column_ops(
+            "INSERT INTO t (a, b) VALUES (1, (SELECT x FROM s)), ((SELECT y FROM s2), 2)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s", "x"), read("s2", "y")],
+                writes: vec![write("t", "a"), write("t", "b")],
+                lineage: vec![
+                    transformation(col("s", "x"), relation("t", "b")),
+                    transformation(col("s2", "y"), relation("t", "a")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn select_mixed_projection_separates_targets_by_position() {
         assert_column_ops(
             "SELECT a, a + b FROM t1",

--- a/sql-insight/tests/column_operation_extractor/resolution.rs
+++ b/sql-insight/tests/column_operation_extractor/resolution.rs
@@ -57,10 +57,6 @@ mod catalog_strict {
         }
     }
 
-    fn relation(table_name: &str, col: &str) -> ColumnTarget {
-        ColumnTarget::Relation(write(table_name, col))
-    }
-
     // Canonical (`public`) table, but a column the catalog *doesn't* list — so
     // the column resolves `Inferred` even though the table is registered.
     fn write_inferred(table_name: &str, col: &str) -> ColumnWrite {
@@ -71,6 +67,24 @@ mod catalog_strict {
             },
             resolution: ResolutionKind::Inferred,
         }
+    }
+
+    // A column-less INSERT fills its column list from the catalog, so the written
+    // column surfaces in the catalog's canonical (quoted) form — like the table
+    // — not as a plain identifier, so a later reference to the same column
+    // matches and dedups.
+    fn filled_write(table_name: &str, col: &str) -> ColumnWrite {
+        ColumnWrite {
+            reference: ColumnReference {
+                table: Some(cataloged_table(table_name)),
+                name: Ident::with_quote('"', col),
+            },
+            resolution: ResolutionKind::Cataloged,
+        }
+    }
+
+    fn filled_relation(table_name: &str, col: &str) -> ColumnTarget {
+        ColumnTarget::Relation(filled_write(table_name, col))
     }
 
     fn relation_inferred(table_name: &str, col: &str) -> ColumnTarget {
@@ -195,10 +209,10 @@ mod catalog_strict {
             ColumnOperation {
                 statement_kind: StatementKind::Insert,
                 reads: vec![read("s", "a"), read("s", "b")],
-                writes: vec![write("t", "x"), write("t", "y")],
+                writes: vec![filled_write("t", "x"), filled_write("t", "y")],
                 lineage: vec![
-                    passthrough(col("s", "a"), relation("t", "x")),
-                    passthrough(col("s", "b"), relation("t", "y")),
+                    passthrough(col("s", "a"), filled_relation("t", "x")),
+                    passthrough(col("s", "b"), filled_relation("t", "y")),
                 ],
                 diagnostics: vec![],
             },
@@ -216,10 +230,10 @@ mod catalog_strict {
             ColumnOperation {
                 statement_kind: StatementKind::Insert,
                 reads: vec![read("s", "a"), read("s", "b"), read("s", "c")],
-                writes: vec![write("t", "x"), write("t", "y")],
+                writes: vec![filled_write("t", "x"), filled_write("t", "y")],
                 lineage: vec![
-                    passthrough(col("s", "a"), relation("t", "x")),
-                    passthrough(col("s", "b"), relation("t", "y")),
+                    passthrough(col("s", "a"), filled_relation("t", "x")),
+                    passthrough(col("s", "b"), filled_relation("t", "y")),
                 ],
                 diagnostics: vec![diag(ColumnLevelDiagnosticKind::InsertColumnsArityMismatch)],
             },
@@ -333,10 +347,10 @@ mod catalog_strict {
                     read("s", "id"),
                     read("s", "a"),
                 ],
-                writes: vec![write("t", "id"), write("t", "a")],
+                writes: vec![filled_write("t", "id"), filled_write("t", "a")],
                 lineage: vec![
-                    passthrough(col("s", "id"), relation("t", "id")),
-                    passthrough(col("s", "a"), relation("t", "a")),
+                    passthrough(col("s", "id"), filled_relation("t", "id")),
+                    passthrough(col("s", "a"), filled_relation("t", "a")),
                 ],
                 diagnostics: vec![],
             },

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -443,6 +443,23 @@ mod insert_statement {
         })];
         assert_crud_table_extraction(sql, expected, vec![Box::new(GenericDialect {})]);
     }
+
+    #[test]
+    fn test_with_wrapped_insert_overwrite_keeps_the_delete_bucket() {
+        use sql_insight::sqlparser::dialect::GenericDialect;
+        // `WITH … INSERT OVERWRITE …` parses as a Query-wrapped Insert, so the
+        // OVERWRITE flag must be read off the peeled insert, not the outer
+        // Query — otherwise the Delete bucket is lost.
+        let sql = "WITH s AS (SELECT a FROM src) INSERT OVERWRITE t1 SELECT a FROM s";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("t1"))],
+            read_tables: vec![cread(table("src"))],
+            update_tables: vec![],
+            delete_tables: vec![cwrite(table("t1"))],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, vec![Box::new(GenericDialect {})]);
+    }
 }
 
 mod update_statement {

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -760,3 +760,88 @@ mod ddl {
         );
     }
 }
+
+mod data_modifying_cte {
+    //! A data-modifying CTE (Postgres `WITH c AS (INSERT / UPDATE / DELETE …) …`)
+    //! is a write root inside the WITH. The statement classifies by its outer
+    //! verb (here a read `SELECT`), but each CTE's target is bucketed by *that
+    //! CTE's* verb — INSERT → Create, UPDATE → Update, DELETE → Delete — not
+    //! folded into the outer kind.
+    use super::*;
+    use sql_insight::sqlparser::dialect::PostgreSqlDialect;
+
+    fn pg() -> Vec<Box<dyn Dialect>> {
+        vec![Box::new(PostgreSqlDialect {})]
+    }
+
+    #[test]
+    fn insert_cte_buckets_target_as_create() {
+        let sql = "WITH c AS (INSERT INTO x (a) SELECT v FROM s) SELECT 1 AS one";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("x"))],
+            read_tables: vec![cread(table("s"))],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, pg());
+    }
+
+    #[test]
+    fn delete_cte_buckets_target_as_delete() {
+        let sql = "WITH c AS (DELETE FROM y WHERE k = 1) SELECT 1 AS one";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![],
+            read_tables: vec![cread(table("y"))],
+            update_tables: vec![],
+            delete_tables: vec![cwrite(table("y"))],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, pg());
+    }
+
+    #[test]
+    fn update_cte_buckets_target_as_update() {
+        let sql = "WITH c AS (UPDATE z SET a = b + 1) SELECT 1 AS one";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![],
+            read_tables: vec![cread(table("z"))],
+            update_tables: vec![cwrite(table("z"))],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, pg());
+    }
+
+    #[test]
+    fn sibling_inserts_into_same_target_surface_per_occurrence() {
+        // Two data-modifying CTEs writing the same table each contribute a
+        // create occurrence (occurrence-based, like reads) — not deduped.
+        let sql = "WITH a AS (INSERT INTO x (c) SELECT v FROM s1), \
+                        b AS (INSERT INTO x (d) SELECT v FROM s2) \
+                   SELECT 1 AS one";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("x")), cwrite(table("x"))],
+            read_tables: vec![cread(table("s1")), cread(table("s2"))],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, pg());
+    }
+
+    #[test]
+    fn sibling_data_modifying_ctes_bucket_by_their_own_verbs() {
+        let sql = "WITH a AS (INSERT INTO x (c1) SELECT v FROM s), \
+                        b AS (UPDATE z SET d = e + 1) \
+                   SELECT 1 AS one";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("x"))],
+            read_tables: vec![cread(table("s")), cread(table("z"))],
+            update_tables: vec![cwrite(table("z"))],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, pg());
+    }
+}

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -1768,3 +1768,82 @@ mod read_write_model {
         );
     }
 }
+
+mod data_modifying_cte {
+    //! A data-modifying CTE (Postgres `WITH c AS (INSERT / UPDATE / DELETE …) …`)
+    //! is a write root inside the WITH even when the outer statement is a read
+    //! `SELECT`: its write target and data-flow lineage surface like a top-level
+    //! DML, rather than being dropped with the statement mis-read as read-only.
+    use super::*;
+
+    #[test]
+    fn insert_cte_surfaces_write_and_lineage() {
+        assert_ops_with(
+            "WITH c AS (INSERT INTO x (a) SELECT v FROM s) SELECT 1 AS one",
+            &PostgreSqlDialect {},
+            TableOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("s")],
+                writes: vec![twrite("x")],
+                lineage: vec![edge("s", "x")],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn delete_cte_surfaces_write_target_without_lineage() {
+        assert_ops_with(
+            "WITH c AS (DELETE FROM y WHERE k = 1) SELECT 1 AS one",
+            &PostgreSqlDialect {},
+            TableOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("y")],
+                writes: vec![twrite("y")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn shared_cte_feeds_each_data_modifying_cte_target() {
+        // A plain CTE referenced by two data-modifying CTEs feeds *each* target
+        // once (per-target dedup keys on the body identity), so both edges
+        // appear.
+        assert_ops_with(
+            "WITH sh AS (SELECT v FROM src), \
+                  a AS (INSERT INTO x (c) SELECT v FROM sh), \
+                  b AS (INSERT INTO y (d) SELECT v FROM sh) \
+             SELECT 1 AS one",
+            &PostgreSqlDialect {},
+            TableOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("src")],
+                writes: vec![twrite("x"), twrite("y")],
+                lineage: vec![edge("src", "x"), edge("src", "y")],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn delete_only_merge_outer_with_data_modifying_cte_keeps_only_cte_lineage() {
+        // A data-modifying CTE forces lineage past the kind gate; a delete-only
+        // MERGE outer must still self-suppress its (non-data-moving) source
+        // feed, so only the CTE's `src -> x` edge appears — not a spurious
+        // `u -> t` from a MERGE that moves no data.
+        assert_ops_with(
+            "WITH c AS (INSERT INTO x (a) SELECT v FROM src) \
+             MERGE INTO t USING u ON t.id = u.id WHEN MATCHED THEN DELETE",
+            &PostgreSqlDialect {},
+            TableOperation {
+                statement_kind: StatementKind::Merge,
+                reads: vec![read("src"), read("t"), read("u")],
+                writes: vec![twrite("x"), twrite("t")],
+                lineage: vec![edge("src", "x")],
+                diagnostics: vec![],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -1556,6 +1556,27 @@ mod catalog_resolution {
     }
 
     #[test]
+    fn dml_sink_read_resolution_is_table_level_not_operand_order() {
+        // The UPDATE sink's table read mirrors the *table*'s catalog match — like
+        // its write (Cataloged: `users` is registered) — not the first hitting
+        // column's resolution, which would otherwise flip with SET operand order
+        // (`id` is a cataloged column → Cataloged; `legacy_id` is not → Inferred).
+        let catalog = Catalog::from_ddl(
+            &GenericDialect {},
+            "CREATE TABLE public.users (id INT, name TEXT)",
+        )
+        .unwrap();
+        for sql in [
+            "UPDATE users SET name = id + users.legacy_id",
+            "UPDATE users SET name = users.legacy_id + id",
+        ] {
+            let ops = ops_with_catalog(sql, &catalog);
+            assert_eq!(ops.reads, vec![cataloged("users")], "reads — {sql}");
+            assert_eq!(ops.writes, vec![cataloged_write("users")], "writes — {sql}");
+        }
+    }
+
+    #[test]
     fn ambiguous_registration_marks_read_ambiguous() {
         // Bare `users` right-anchored-matches two registrations under
         // different schemas (no default schema to disambiguate) →

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -790,6 +790,23 @@ mod lineage {
     }
 
     #[test]
+    fn values_scalar_subquery_feeds_the_target() {
+        // A scalar subquery in a VALUES cell feeds the target like an
+        // `INSERT … SELECT` value: `s -> t`. (The VALUES source fed nothing
+        // before — it produced no lineage at all.)
+        assert_ops(
+            "INSERT INTO t (a) VALUES ((SELECT x FROM s))",
+            TableOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s")],
+                writes: vec![twrite("t")],
+                lineage: vec![edge("s", "t")],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn aggregate_source_feeds_lineage() {
         // The source projects an aggregate over a GROUP BY — feeding still
         // traces through the `Aggregate` to the scanned table.

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -770,6 +770,26 @@ mod lineage {
     }
 
     #[test]
+    fn value_position_in_subquery_lhs_feeds_the_target() {
+        // The LHS of `… IN (…)` in *value* position feeds the target — even when
+        // it is a scalar subquery: `s2 -> dst` appears, matching the column edge
+        // `s2.y -> dst.f`. (Regression: the LHS used to be classified as a
+        // filter on the table side, dropping `s2 -> dst` and disagreeing with
+        // column lineage.) The RHS membership subquery `s` stays a filter — read
+        // but never a feeding source.
+        assert_ops(
+            "INSERT INTO dst (f) SELECT (SELECT y FROM s2) IN (SELECT x FROM s) FROM t",
+            TableOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s2"), read("s"), read("t")],
+                writes: vec![twrite("dst")],
+                lineage: vec![edge("s2", "dst"), edge("t", "dst")],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn aggregate_source_feeds_lineage() {
         // The source projects an aggregate over a GROUP BY — feeding still
         // traces through the `Aggregate` to the scanned table.


### PR DESCRIPTION
A batch of extraction-correctness fixes, each its own commit with regression tests. The full suite stays green (718) and the CI quartet (fmt / clippy `-D warnings` / test / doc `-Dwarnings`) is clean throughout.

### Resolution

- **A DML target is always a real table, never a CTE.** INSERT / UPDATE / DELETE / MERGE resolved their write target inconsistently when its name collided with a declared CTE — INSERT fabricated a phantom write, UPDATE / DELETE dropped silently, only MERGE flagged. Resolve the target name CTE-blind: a catalog match wins (the base table), an uncatalogued declared-CTE name is flagged `UnsupportedStatement` and dropped, any other name stays `Inferred`. Mirrors a database, which resolves the target against the catalog, not the WITH list.
- **A DML sink's table read carries the table-level catalog match**, not the first hitting column's — so `UPDATE users SET name = id + users.legacy_id` no longer flips the sink read between `Cataloged` and `Inferred` with SET operand order (it matches the write side, order-independently).
- **A derived-table / CTE column-alias list applies over a `SELECT *` body.** `(SELECT * FROM t) AS d(x)` / `WITH c(x) AS (SELECT * FROM t)` bind a reference to the declared column to the derived relation instead of dangling as a phantom unresolved read.
- **A multi-stage pipe's computed/renamed column isn't treated as an identity passthrough.** `FROM t |> SELECT a + b AS s |> SELECT s` no longer fabricates a phantom `t.s`, and a renamed column carried through `EXTEND` traces `t.a -> x` rather than mis-attributing to `t.x`.

### Lineage

- **A data-modifying CTE surfaces its writes, lineage, and CRUD effect.** `WITH c AS (INSERT … RETURNING …) SELECT … FROM c` was mis-reported as a read-only SELECT; every DML root (the outer root plus each data-modifying CTE body, recursively) now contributes, each CRUD-bucketed by its own verb.
- **An `IN`-subquery's value-position LHS feeds table lineage**, matching column lineage — a scalar-subquery LHS now appears as a source on both surfaces (they had disagreed).
- **A scalar subquery in a `VALUES` cell flows to the target**, like the equivalent `INSERT … SELECT` (it was dropped); each row's cells pair positionally with the target columns.
- **USING / NATURAL merge columns fan in on an UPDATE target-clause join.** `UPDATE t1 JOIN t2 USING (id) SET t2.a = id` fans `id` into both sides instead of leaving it ambiguous, matching the SELECT path.

### Diagnostics / CRUD / catalog / CLI

- **A WITH-wrapped `INSERT OVERWRITE` keeps its Delete CRUD bucket** (the OVERWRITE flag was read off the outer `Query` wrapper, not the peeled Insert).
- **A MERGE WHEN-INSERT keeps all named target columns** as writes even when the value list is shorter (matching a plain INSERT), while lineage still pairs only valued columns.
- **`Catalog::from_ddl` skips a table whose name has a non-identifier segment** (e.g. Snowflake `IDENTIFIER('t')`) instead of dropping the segment and registering a mis-segmented phantom.
- **A column-less INSERT / MERGE-insert fills its columns in canonical (quoted) form**, so a case-exact column like `"MyCol"` matches the catalog (`Cataloged`) and a user's own quoted reference.
- **The CLI `--ddl-file` catalog is built with the `--casing` override**, so a casing override no longer silently breaks every catalog lookup.

Two related findings were deliberately left as-is: the normalizer abstracting `ORDER BY` / `GROUP BY` ordinals to a placeholder (consistent with its "every literal → `?`" stance; a context-aware exception would be complex and regression-prone), and a set-operation's trailing `ORDER BY` resolving against an empty scope (the correct read semantics there are themselves ambiguous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
