### PR TITLE
ci: upload fork-PR coverage to Codecov via workflow_run

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,0 +1,46 @@
+name: Coverage report
+
+# Uploads fork-PR coverage to Codecov with the token (the PR build can't — forks
+# get no secrets). Runs after the Rust workflow; never executes fork code.
+on:
+  workflow_run:
+    workflows: [ "Rust" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+  actions: read   # download an artifact from the triggering run
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read coverage metadata
+        id: meta
+        # Anchored regexes accept only an int / 40-hex SHA, so the untrusted
+        # artifact can't inject into $GITHUB_OUTPUT; a missing line fails the step.
+        run: |
+          set -euo pipefail
+          grep -m1 -E '^PR_NUMBER=[0-9]+$'    coverage-meta.env >> "$GITHUB_OUTPUT"
+          grep -m1 -E '^PR_SHA=[0-9a-f]{40}$' coverage-meta.env >> "$GITHUB_OUTPUT"
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+        with:
+          files: codecov.json
+          disable_search: true
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: takaebato/sql-insight
+          # This run's CI env is the wrong commit; pin the report to the PR.
+          override_commit: ${{ steps.meta.outputs.PR_SHA }}
+          override_pr: ${{ steps.meta.outputs.PR_NUMBER }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -99,7 +99,9 @@ jobs:
         # `--codecov` (vs `--lcov`) preserves region coverage on Codecov's UI;
         # `--lcov` collapses to line-only there.
         run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+      # Push: secrets are available, upload directly.
       - name: Upload coverage reports to Codecov
+        if: github.event_name == 'push'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: codecov.json
@@ -107,3 +109,22 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           slug: takaebato/sql-insight
+      # PR (incl. forks): no secrets here, so stash the report + PR id as an
+      # artifact for the Coverage report workflow to upload with the token.
+      - name: Save coverage metadata
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+            echo "PR_SHA=${{ github.event.pull_request.head.sha }}"
+          } > coverage-meta.env
+      - name: Upload coverage artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: coverage
+          path: |
+            codecov.json
+            coverage-meta.env
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## What

Make Codecov coverage uploads work for **fork pull requests** (which receive no
secrets), so fork PRs still get a coverage comment.

## How

A two-stage, fork-safe flow:

- **`rust.yaml`** (`test-coverage`): on `push`, upload to Codecov directly with
  the token; on `pull_request`, instead stash `codecov.json` plus the PR's
  commit/number as an artifact — no secrets needed, so forks are fine.
- **`coverage-report.yaml`** (new, `workflow_run`): runs in the base repo *with*
  secrets after the Rust workflow completes, downloads the artifact, and uploads
  with the token and `override_commit/_pr/_branch` so Codecov attaches the report
  to the PR and comments. The comment comes from Codecov's app, so no write
  permission is required.

## Security

- The handler **never executes fork code** — it only downloads the artifact and
  forwards `codecov.json` to Codecov.
- It runs **read-only** (`contents: read`, `actions: read`) and uses no cache.
- The untrusted artifact metadata is accepted only via anchored regexes
  (`^PR_NUMBER=[0-9]+$`, `^PR_SHA=[0-9a-f]{40}$`), so nothing can be injected into
  `$GITHUB_OUTPUT`.

## Activation note

`workflow_run` triggers only from the workflow definition on the **default
branch**, so `coverage-report.yaml` won't fire until it's on `master`. Verify
against a real fork PR after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
