### PR TITLE
ci: add PR-title lint and release-plz release automation

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,74 @@
+name: PR Title
+
+# Enforce Conventional Commits on the PR title. With squash-merge configured to
+# use the PR title as the commit subject, this keeps `master` history clean and
+# machine-readable, which is what release-plz reads to compute version bumps and
+# the changelog.
+on:
+  pull_request_target:
+    types: [ opened, edited, reopened, synchronize ]
+
+# `write` is needed to post/update the validation comment. The job never checks
+# out PR code, so pull_request_target stays safe (no untrusted code runs); the
+# elevated token is what lets the comment work on PRs from forks too.
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types. Scopes stay unrestricted (e.g. `feat(cli):`).
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            perf
+            test
+            ci
+            build
+            chore
+            revert
+          # A single-commit PR may be squashed using the commit message instead
+          # of the PR title, so validate that lone commit too.
+          validateSingleCommit: true
+
+      # On failure: post (or update) a sticky comment with the error. The lint
+      # step still fails the job, so the required check blocks merge; `always()`
+      # just lets this comment run despite that failure.
+      # NOTE: keep the "Allowed types" list below in sync with `types:` above.
+      - if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: pr-title-lint
+          message: |
+            ❌ **PR title doesn't follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec.**
+
+            Use `<type>(<optional scope>): <subject>`, with a trailing `!` for a breaking change (e.g. `feat!: …`).
+
+            Allowed types: `feat` `fix` `docs` `refactor` `perf` `test` `ci` `build` `chore` `revert`
+
+            <details><summary>Details</summary>
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+            </details>
+
+      # On success: update the same comment in place to show it's resolved.
+      # (Prefer `delete: true` over `message` here if you'd rather leave no
+      # comment on PRs whose title was valid from the start.)
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: pr-title-lint
+          message: |
+            ✅ PR title follows the Conventional Commits spec.

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -36,6 +36,7 @@ jobs:
             build
             chore
             revert
+            deprecate
           # A single-commit PR may be squashed using the commit message instead
           # of the PR title, so validate that lone commit too.
           validateSingleCommit: true
@@ -53,7 +54,7 @@ jobs:
 
             Use `<type>(<optional scope>): <subject>`, with a trailing `!` for a breaking change (e.g. `feat!: …`).
 
-            Allowed types: `feat` `fix` `docs` `refactor` `perf` `test` `ci` `build` `chore` `revert`
+            Allowed types: `feat` `fix` `docs` `refactor` `perf` `test` `ci` `build` `chore` `revert` `deprecate`
 
             <details><summary>Details</summary>
 

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -1,0 +1,66 @@
+name: Release-plz
+
+# release-plz reads Conventional Commits on `master` and:
+#   - release-plz-pr: opens/updates a "Release PR" that bumps versions and
+#     updates CHANGELOG.md (nothing is published — this PR is the review point).
+#   - release-plz-release: once that PR is merged, publishes to crates.io and
+#     creates the git tag + GitHub Release.
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Run release-plz
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    # Avoid two PR-update runs racing on the same branch.
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Run release-plz
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,11 @@ Rules that bite if forgotten (the why is in `ARCHITECTURE.md`):
   variants). Per-construct "arm coverage" modules (one case per AST variant)
   are encouraged — they pin behavior and force a test when a `match` grows.
   Err toward more coverage.
+
+## Pull requests
+
+- **PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)**,
+  CI-enforced via `.github/workflows/pr-title.yaml`. Squash-merge uses the title
+  as the commit subject, which release-plz reads to compute per-crate version
+  bumps and changelogs — so `fix:` / `feat:` / `feat!:` (breaking) on the title
+  is what ships. Allowed types live in that workflow.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ members = ["sql-insight", "sql-insight-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
 authors = ["Takahiro Ebato <takahiro.ebato@gmail.com>"]
 homepage = "https://github.com/takaebato/sql-insight"
 repository = "https://github.com/takaebato/sql-insight"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -34,16 +34,17 @@ protect_breaking_commits = true
 commit_parsers = [
     { message = "^Merge ", skip = true },
     { message = "^feat", group = "<!-- 0 -->Added" },
-    { message = "^fix", group = "<!-- 1 -->Fixed" },
-    { message = "^perf", group = "<!-- 2 -->Performance" },
-    { message = "^docs", group = "<!-- 3 -->Documentation" },
-    { message = "^revert", group = "<!-- 4 -->Changed" },
-    { message = "^refactor", group = "<!-- 5 -->Other Changes" },
-    { message = "^test", group = "<!-- 5 -->Other Changes" },
-    { message = "^ci", group = "<!-- 5 -->Other Changes" },
-    { message = "^build", group = "<!-- 5 -->Other Changes" },
-    { message = "^chore", group = "<!-- 5 -->Other Changes" },
-    { message = ".*", group = "<!-- 5 -->Other Changes" },
+    { message = "^revert", group = "<!-- 1 -->Changed" },
+    { message = "^deprecate", group = "<!-- 2 -->Deprecated" },
+    { message = "^fix", group = "<!-- 3 -->Fixed" },
+    { message = "^perf", group = "<!-- 4 -->Performance" },
+    { message = "^docs", group = "<!-- 5 -->Documentation" },
+    { message = "^refactor", group = "<!-- 6 -->Other Changes" },
+    { message = "^test", group = "<!-- 6 -->Other Changes" },
+    { message = "^ci", group = "<!-- 6 -->Other Changes" },
+    { message = "^build", group = "<!-- 6 -->Other Changes" },
+    { message = "^chore", group = "<!-- 6 -->Other Changes" },
+    { message = ".*", group = "<!-- 6 -->Other Changes" },
 ]
 
 # Custom body: a top "Breaking Changes" section (every commit flagged

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,96 @@
+# release-plz configuration.
+#
+# Versions are independent per crate (each bumps only on its own changes), but
+# the git tag and GitHub Release follow the *library* only: `sql-insight` owns a
+# single plain `vX.Y.Z` tag, matching the project's existing tag history. The CLI
+# publishes to crates.io and keeps its own changelog, but is not tagged or
+# GitHub-released here — crates.io is the record of its versions (the common
+# "flagship-crate tag" pattern). This is safe because release-plz baselines a
+# *published* crate on crates.io (its version + recorded commit), not on a git
+# tag, so the CLI's bump and changelog are computed correctly without a CLI tag.
+# A breaking library bump still cascades a small CLI bump (release-plz updates
+# the CLI's `sql-insight` dependency requirement).
+#
+# See https://release-plz.dev/docs/config for the full schema.
+
+[workspace]
+# Default for all crates: no git tag / GitHub Release. The library re-enables
+# both below, so only it is tagged + released.
+git_tag_enable = false
+git_release_enable = false
+
+[changelog]
+# Keep a Changelog format. `protect_breaking_commits` keeps breaking changes
+# visible even if a future skip rule would otherwise drop them.
+protect_breaking_commits = true
+
+# Group order is set by the `<!-- N -->` sort prefixes (Tera sorts groups
+# alphabetically); the prefixes are hidden at render time by `striptags` in the
+# body below. Internal types are bucketed into "Other Changes" rather than
+# dropped, so their contributors still get credited. The trailing `.*` catches
+# anything unmatched so it never lands in an unnamed group; merge commits are
+# skipped first so they don't show up via that catch-all (relevant mainly for the
+# first run's backlog — squash-merged history has no merge commits).
+commit_parsers = [
+    { message = "^Merge ", skip = true },
+    { message = "^feat", group = "<!-- 0 -->Added" },
+    { message = "^fix", group = "<!-- 1 -->Fixed" },
+    { message = "^perf", group = "<!-- 2 -->Performance" },
+    { message = "^docs", group = "<!-- 3 -->Documentation" },
+    { message = "^revert", group = "<!-- 4 -->Changed" },
+    { message = "^refactor", group = "<!-- 5 -->Other Changes" },
+    { message = "^test", group = "<!-- 5 -->Other Changes" },
+    { message = "^ci", group = "<!-- 5 -->Other Changes" },
+    { message = "^build", group = "<!-- 5 -->Other Changes" },
+    { message = "^chore", group = "<!-- 5 -->Other Changes" },
+    { message = ".*", group = "<!-- 5 -->Other Changes" },
+]
+
+# Custom body: a top "Breaking Changes" section (every commit flagged
+# `commit.breaking`, via `!` or a BREAKING CHANGE footer), then the normal groups
+# with breaking commits excluded and empty groups skipped — so a breaking change
+# is listed once, at the top. `striptags` honors the `<!-- N -->` sort prefixes;
+# ` by @user in #PR` adds attribution (commit.remote.* is filled by release-plz's
+# GitHub integration in CI).
+body = '''
+
+## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% set breaking = commits | filter(attribute="breaking", value=true) -%}
+{% if breaking | length > 0 %}
+### ⚠️ Breaking Changes
+
+{% for commit in breaking %}
+{%- if commit.scope -%}
+- *({{ commit.scope }})* {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %}
+{% else -%}
+- {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %}
+{% endif -%}
+{% endfor -%}
+{% endif -%}
+{% for group, group_commits in commits | group_by(attribute="group") %}
+{%- set rest = group_commits | filter(attribute="breaking", value=false) -%}
+{% if rest | length > 0 %}
+### {{ group | striptags | trim | upper_first }}
+
+{% for commit in rest %}
+{%- if commit.scope -%}
+- *({{ commit.scope }})* {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %}{%- if commit.links %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}) {% endfor -%}){% endif %}
+{% else -%}
+- {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %}
+{% endif -%}
+{% endfor -%}
+{% endif -%}
+{% endfor %}'''
+
+[[package]]
+name = "sql-insight"
+# The library owns the single plain `vX.Y.Z` tag + GitHub Release. Its changelog
+# lives at the default per-crate location (sql-insight/CHANGELOG.md), same as the
+# CLI's (sql-insight-cli/CHANGELOG.md).
+git_tag_enable = true
+git_release_enable = true
+git_tag_name = "v{{ version }}"
+
+# sql-insight-cli inherits the workspace defaults: it versions and publishes to
+# crates.io independently and keeps its own sql-insight-cli/CHANGELOG.md, but is
+# not tagged or GitHub-released (crates.io is the record of its versions).

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -24,6 +24,20 @@ git_release_enable = false
 # visible even if a future skip rule would otherwise drop them.
 protect_breaking_commits = true
 
+# Changelog preamble. Kept in sync with the header already in each CHANGELOG.md
+# (Keep a Changelog 1.1.0) so release-plz strips and re-inserts it cleanly —
+# release-plz's built-in default links 1.0.0, so we override it here.
+header = '''
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+'''
+
 # Group order is set by the `<!-- N -->` sort prefixes (Tera sorts groups
 # alphabetically); the prefixes are hidden at render time by `striptags` in the
 # body below. Internal types are bucketed into "Other Changes" rather than

--- a/sql-insight-cli/Cargo.toml
+++ b/sql-insight-cli/Cargo.toml
@@ -10,7 +10,7 @@ include = [
     "LICENSE.txt",
 ]
 readme = "README.md"
-version = { workspace = true }
+version = "0.2.0"
 edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/sql-insight/CHANGELOG.md
+++ b/sql-insight/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/sql-insight/CHANGELOG.md
+++ b/sql-insight/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ## [v0.2.0](https://github.com/takaebato/sql-insight/tree/v0.2.0) (2024-07-05)

--- a/sql-insight/Cargo.toml
+++ b/sql-insight/Cargo.toml
@@ -10,7 +10,7 @@ include = [
     "LICENSE.txt",
 ]
 readme = "README.md"
-version = { workspace = true }
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = "1.89.0"
 homepage = { workspace = true }


### PR DESCRIPTION
## What

Conventional-Commits-based release automation for the workspace.

- **PR-title lint** (`ci`): validates PR titles against the Conventional Commits spec and posts/updates a sticky comment with the result. With squash-merge, the title becomes the commit subject release-plz reads.
- **Independent crate versions** (`build`): `sql-insight` and `sql-insight-cli` no longer share `workspace.package.version`; each releases on its own changes.
- **release-plz** (`ci`): Release PR → crates.io publish + git tag + GitHub Release. The library owns a single plain `vX.Y.Z` tag (the CLI is tracked on crates.io). Changelogs use Keep a Changelog with a top **Breaking Changes** section and `by @user in #PR` attribution. The existing changelog moves to `sql-insight/CHANGELOG.md` (per-crate layout).
- **docs**: `CLAUDE.md` notes the PR-title convention.

## Required GitHub settings (manual — needed before this works)

1. Add secret `CARGO_REGISTRY_TOKEN` (crates.io; able to publish both crates).
2. Pull Requests → enable squash merge + default commit message = **Pull request title and description**.
3. Actions → General → enable **Allow GitHub Actions to create and approve pull requests** (release-plz needs it to open the Release PR).
4. Branch protection → require the **Validate PR title (Conventional Commits)** check.

## Notes

- The first Release PR is the verification point: it shows the generated changelog (backlog since v0.2.0), computed bumps, and tag names — nothing publishes until it is merged.
- Validated locally: `actionlint` clean on both workflows; `release-plz.toml` parses; `cargo metadata` resolves with independent versions. Tera changelog rendering is confirmed on the first Release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
