### PR TITLE
ci: keep non-conventional commits in the changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -24,6 +24,12 @@ git_release_enable = false
 # visible even if a future skip rule would otherwise drop them.
 protect_breaking_commits = true
 
+# Keep non-conventional commits (no `type:` prefix) instead of dropping them;
+# they land in "Other Changes" via the catch-all parser. This matters for the
+# historical backlog (commits predating the PR-title convention) — new commits
+# are all conventional, so it is a no-op going forward.
+filter_unconventional = false
+
 # Changelog preamble. Kept in sync with the header already in each CHANGELOG.md
 # (Keep a Changelog 1.1.0) so release-plz strips and re-inserts it cleanly —
 # release-plz's built-in default links 1.0.0, so we override it here.


### PR DESCRIPTION
## Problem

The first Release PR (#41) silently dropped every commit that isn't a Conventional Commit — including major work like #31 (operator extraction) and #33 (the extraction-correctness pass), plus the external contributions #7/#9.

Root cause: the release-plz version that ran (0.3.159) inherits git-cliff's default `filter_unconventional = true`, which discards non-conventional commits *before* the `commit_parsers` run — so the `.*` catch-all never sees them.

## Fix

Set `filter_unconventional = false` in `release-plz.toml`. Non-conventional commits are kept and routed to **Other Changes** via the catch-all.

## Effect

- Merging this regenerates Release PR #41 with the previously-missing commits under **Other Changes**.
- The big ones (#31/#33) land in Other Changes (not Added) because they lack a `feat:` prefix — recategorize by hand in the Release PR if desired.
- This only matters for the historical backlog; new commits are all conventional (PR-title lint), so it is a no-op going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
