### PR TITLE
ci: remove unsupported filter_unconventional release-plz key

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -24,12 +24,6 @@ git_release_enable = false
 # visible even if a future skip rule would otherwise drop them.
 protect_breaking_commits = true
 
-# Keep non-conventional commits (no `type:` prefix) instead of dropping them;
-# they land in "Other Changes" via the catch-all parser. This matters for the
-# historical backlog (commits predating the PR-title convention) — new commits
-# are all conventional, so it is a no-op going forward.
-filter_unconventional = false
-
 # Changelog preamble. Kept in sync with the header already in each CHANGELOG.md
 # (Keep a Changelog 1.1.0) so release-plz strips and re-inserts it cleanly —
 # release-plz's built-in default links 1.0.0, so we override it here.


### PR DESCRIPTION
## Problem

PR #42 added `filter_unconventional = false` to `release-plz.toml`, but that key is **not supported by release-plz 0.3.159** (the latest release — it only exists in unreleased release-plz). Since #42 merged, the release-plz workflow on `master` now fails to parse the config:

```
unknown field `filter_unconventional`, expected one of `header`, `body`, `trim`,
`commit_preprocessors`, `postprocessors`, `sort_commits`, `link_parsers`,
`commit_parsers`, `protect_breaking_commits`, `tag_pattern`
```

## Fix

Remove the unsupported key, restoring a valid config so release-plz works again.

## Follow-up (separate)

The original goal — including pre-convention (non-`type:`) commits like #31/#33 and the external #7/#9 in the changelog — has **no released config/upgrade fix** (the toggle is unreleased). It is a one-time historical-backlog gap; future commits are all conventional (PR-title lint). We'll handle that gap manually rather than via config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
