### PR TITLE
feat(cli): add --pretty option to format command

### DIFF
--- a/sql-insight-cli/README.md
+++ b/sql-insight-cli/README.md
@@ -15,10 +15,12 @@ cargo install sql-insight-cli
 
 ## Commands
 
-- `format` — pretty-print SQL to a standardized layout (comments are not
-  preserved — the parser does not retain them in the AST).
+- `format` — re-emit SQL in a standardized layout: single-line by default,
+  or multi-line indented with `--pretty` (comments are not preserved — the
+  parser does not retain them in the AST).
 - `normalize` — abstract literals to placeholders (`--unify-in-list` /
-  `--unify-values` collapse repetitive shapes).
+  `--unify-values` collapse repetitive shapes; `--alphabetize-insert-columns`
+  sorts INSERT column lists, only with `--unify-values`).
 - `extract crud` — tables bucketed by Create / Read / Update / Delete.
 - `extract table-ops` — table-level reads / writes / lineage per statement.
 - `extract column-ops` — the same at column granularity, with lineage kinds.
@@ -43,6 +45,15 @@ guessing.
 $ sql-insight format "SELECT   *   FROM users   WHERE id = 1;"
 SELECT * FROM users WHERE id = 1
 
+$ sql-insight format --pretty "SELECT a, b FROM users WHERE id = 1"
+SELECT
+  a,
+  b
+FROM
+  users
+WHERE
+  id = 1
+
 $ sql-insight normalize "SELECT * FROM users WHERE id = 1"
 SELECT * FROM users WHERE id = ?
 
@@ -58,7 +69,10 @@ $ sql-insight extract column-ops "INSERT INTO users (name) SELECT LOWER(name) FR
 
 ## Options (extract commands)
 
-- `--dialect <name>` — parse under a specific dialect (default `generic`).
+`--dialect <name>` is available on **every** command (`format` / `normalize` /
+`extract`) — parse under a specific dialect (default `generic`). The options
+below are specific to `extract`:
+
 - `--format <text|json>` — `json` emits one array of per-statement results.
 - `--ddl-file <path>` — a DDL file (`CREATE TABLE`s) to resolve against;
   enables catalog-aware analysis (canonicalized identities, strict columns).

--- a/sql-insight-cli/src/executor.rs
+++ b/sql-insight-cli/src/executor.rs
@@ -6,6 +6,7 @@ use sql_insight::extractor::{
     extract_table_operations_with_options, ColumnLineageKind, ColumnOperation, ColumnTarget,
     ExtractorOptions, TableOperation,
 };
+use sql_insight::formatter::FormatterOptions;
 use sql_insight::normalizer::NormalizerOptions;
 use sql_insight::sqlparser::dialect::{self, Dialect};
 use sql_insight::{
@@ -25,19 +26,30 @@ fn get_dialect(dialect_name: Option<&str>) -> Result<Box<dyn dialect::Dialect>, 
 pub struct FormatExecutor {
     sql: String,
     dialect_name: Option<String>,
+    options: FormatterOptions,
 }
 
 impl FormatExecutor {
     pub fn new(sql: String, dialect_name: Option<String>) -> Self {
-        Self { sql, dialect_name }
+        Self {
+            sql,
+            dialect_name,
+            options: FormatterOptions::new(),
+        }
+    }
+
+    pub fn with_options(mut self, options: FormatterOptions) -> Self {
+        self.options = options;
+        self
     }
 }
 
 impl CliExecutable for FormatExecutor {
     fn execute(&self) -> Result<Vec<String>, Error> {
-        sql_insight::formatter::format(
+        sql_insight::formatter::format_with_options(
             get_dialect(self.dialect_name.as_deref())?.as_ref(),
             self.sql.as_ref(),
+            self.options.clone(),
         )
     }
 }

--- a/sql-insight-cli/src/main.rs
+++ b/sql-insight-cli/src/main.rs
@@ -6,6 +6,7 @@ use crate::executor::{
 };
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use sql_insight::error::Error;
+use sql_insight::formatter::FormatterOptions;
 use sql_insight::normalizer::NormalizerOptions;
 use sql_insight::CaseRule;
 use std::io::{self, IsTerminal, Read};
@@ -38,6 +39,18 @@ struct CommonOptions {
     /// Read statements interactively from a prompt (terminate each with `;`).
     #[clap(short, long, group = "source")]
     interactive: bool,
+}
+
+#[derive(Parser, Debug)]
+struct FormatCommandOptions {
+    #[clap(flatten)]
+    common_options: CommonOptions,
+    /// Pretty-print each statement across multiple indented lines (one item
+    /// per line) instead of the default single line. For example, `SELECT a,
+    /// b FROM t1` becomes a multi-line block with `a` / `b` indented under
+    /// `SELECT`.
+    #[clap(long)]
+    pretty: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -92,7 +105,7 @@ impl ProcessType {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Format SQL
-    Format(CommonOptions),
+    Format(FormatCommandOptions),
     /// Normalize SQL
     Normalize(NormalizeCommandOptions),
     /// Extract what a statement touches, at a chosen granularity
@@ -227,7 +240,7 @@ impl Commands {
     /// The source / dialect options shared by every command.
     fn common(&self) -> &CommonOptions {
         match self {
-            Commands::Format(opts) => opts,
+            Commands::Format(opts) => &opts.common_options,
             Commands::Normalize(opts) => &opts.common_options,
             Commands::Extract { target } => target.common(),
         }
@@ -318,7 +331,10 @@ impl Commands {
 
     fn executor(&self, sql: String) -> Box<dyn CliExecutable> {
         match self {
-            Commands::Format(opts) => Box::new(FormatExecutor::new(sql, opts.dialect.clone())),
+            Commands::Format(opts) => Box::new(
+                FormatExecutor::new(sql, opts.common_options.dialect.clone())
+                    .with_options(FormatterOptions::new().with_pretty(opts.pretty)),
+            ),
             Commands::Normalize(opts) => Box::new(
                 NormalizeExecutor::new(sql, opts.common_options.dialect.clone()).with_options(
                     NormalizerOptions::new()

--- a/sql-insight-cli/tests/integration.rs
+++ b/sql-insight-cli/tests/integration.rs
@@ -25,6 +25,20 @@ mod integration {
         }
 
         #[test]
+        fn test_format_pretty() {
+            // `--pretty` switches to sqlparser's multi-line alternate form
+            // (one item per line, indented), applied per statement.
+            sql_insight_cmd()
+                .arg("format")
+                .arg("--pretty")
+                .arg("select a, b from t1 where c = 1;")
+                .assert()
+                .success()
+                .stdout("SELECT\n  a,\n  b\nFROM\n  t1\nWHERE\n  c = 1\n")
+                .stderr("");
+        }
+
+        #[test]
         fn test_format_with_dialect() {
             sql_insight_cmd()
                 .arg("format")


### PR DESCRIPTION
## What

Add a `--pretty` flag to the `format` command, and close a few README gaps found along the way.

### Feature: `format --pretty`

The library's `formatter` already supported multi-line pretty-printing via `FormatterOptions::pretty` / `format_with_options` (sqlparser's `{:#}` alternate `Display`) — the CLI just never exposed it. This wires it through:

- New `FormatCommandOptions` struct, mirroring `NormalizeCommandOptions` (`common_options` flattened + a `--pretty` flag), replacing the bare `CommonOptions` the `Format` variant used.
- `FormatExecutor` gains a `with_options(FormatterOptions)` builder and calls `format_with_options`, matching the `NormalizeExecutor` shape.

```
$ sql-insight format --pretty "SELECT a, b FROM users WHERE id = 1"
SELECT
  a,
  b
FROM
  users
WHERE
  id = 1
```

No library changes — pure CLI wiring.

### README fixes (found while documenting the flag)

- Document `normalize`'s `--alphabetize-insert-columns` (was missing entirely; only effective with `--unify-values`).
- Clarify that `--dialect` applies to **every** command, not just `extract` (it was listed only under the extract-specific options heading).
- Correct the `format` description: the default is single-line, not "pretty-print" — pretty is now opt-in via `--pretty`.

## Testing

- New `test_format_pretty` integration test pins the multi-line output.
- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --all` green; `cargo doc` (warnings-as-errors, CI config) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)