### PR TITLE
ci: add cargo-deny supply-chain and license check

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,0 +1,42 @@
+name: Security Audit
+
+# cargo-deny runs only when the dependency set or policy changes (paths filter),
+# on pull requests and master pushes, plus a daily schedule. On PRs it runs the
+# deterministic checks only (bans / licenses / sources) — a newly-published RUSTSEC
+# advisory is an external event that should not fail an unrelated PR. Master pushes
+# and the daily schedule run the full check, including advisories.
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security-audit.yaml'
+  push:
+    branches: [ "master" ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security-audit.yaml'
+  schedule:
+    - cron: '0 22 * * *' # daily at 22:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@db5fb34fa772531a3ece57ca434f579eb334e0fb # v2
+        with:
+          tool: cargo-deny
+      - name: cargo deny check (deterministic — pull requests)
+        if: github.event_name == 'pull_request'
+        run: cargo deny check bans licenses sources
+      - name: cargo deny check (full — master push & schedule)
+        if: github.event_name != 'pull_request'
+        run: cargo deny check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+# cargo-deny — supply-chain, license, and source gate.
+# Run locally with `cargo deny check`; CI runs it on every push / PR.
+
+[graph]
+# Check the full feature set (e.g. the `serde` optional feature), not just the
+# defaults, so feature-gated dependencies are scanned too.
+all-features = true
+
+[advisories]
+# RUSTSEC advisories: vulnerabilities and unmaintained crates are denied by
+# default; reject yanked crates too. Add IDs to `ignore` only with a documented
+# rationale.
+yanked = "deny"
+ignore = []
+
+[licenses]
+# Permissive licenses actually present in the dependency tree:
+#   - Unicode-3.0: unicode-ident's expression ANDs it in.
+#   - BSL-1.0: rustyline's Windows clipboard deps (clipboard-win / error-code).
+#   - Apache-2.0 WITH LLVM-exception: ar_archive_writer, pulled via cc's build
+#     path (sqlparser -> recursive -> stacker -> psm -> cc).
+# memchr ("Unlicense OR MIT") and foldhash 0.1.5 are satisfied via MIT/Apache-2.0,
+# so their other licenses (Unlicense / Zlib) need not be allowed.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+    "BSL-1.0",
+]
+
+[bans]
+# Duplicate versions of a crate are surfaced but not fatal (common transitively).
+multiple-versions = "warn"
+# Wildcard ("*") version requirements are rejected — they defeat the lockfile.
+wildcards = "deny"
+
+[sources]
+# Only crates.io — reject crates from unknown registries or git remotes.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## What

Add a `cargo-deny` supply-chain gate: a `deny.toml` plus a CI job (`cargo deny check`).

Checks:
- **advisories** — RUSTSEC vulnerabilities and unmaintained crates (denied).
- **licenses** — allow-list of the licenses actually in the tree (`MIT`, `Apache-2.0`, `Unicode-3.0`, `BSL-1.0`).
- **sources** — crates.io only (reject unknown registries / git remotes).
- **bans** — duplicate-version warnings (non-fatal).

The job installs cargo-deny via `taiki-e/install-action` — the same pattern already used for `cargo-msrv` / `cargo-llvm-cov`.

Setting this up already surfaced a real advisory (RUSTSEC-2026-0007 in `bytes`, pulled via the CLI's `tokio` dev-dependency); it's fixed in `bytes >= 1.11.1`, which a fresh resolve picks up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
