### PR TITLE
ci: changelog breaking-change workflow, version-bump docs, and keywords

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+Title → the squash commit subject. Use Conventional Commits; add `!` for a
+breaking change (a removed/renamed command, a changed output format or result
+set, an incompatible API):
+  feat(cli): add --pretty to format
+  fix(cli)!: remove the extract table command
+
+Below → the squash commit body: what changed and why (the title already
+summarizes, so add context only if it helps).
+-->
+
+
+
+<!--
+Breaking change? Mark the PR title with `!`, then uncomment the block below
+(remove the comment markers wrapping it) and fill the crate label(s) that apply —
+delete the one you don't use. Keep it short: what changed and the replacement;
+link to the docs for how to use it. Only this range is copied into the changelog's
+"Breaking Changes" section (it lands in both crates' changelogs, so readers pick
+their part). Paragraphs and code fences are fine.
+-->
+
+<!--
+**▼ changelog ▼**
+
+**sql-insight:**
+
+**sql-insight-cli:**
+
+**▲ changelog ▲**
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,10 @@ Rules that bite if forgotten (the why is in `ARCHITECTURE.md`):
   as the commit subject, which release-plz reads to compute per-crate version
   bumps and changelogs — so `fix:` / `feat:` / `feat!:` (breaking) on the title
   is what ships. Allowed types live in that workflow.
+- **Breaking-change changelog notes live in the PR description**, between the
+  `**▼ changelog ▼**` / `**▲ changelog ▲**` markers (uncomment the block in
+  `.github/pull_request_template.md`; `!` on the title flags it breaking). Label
+  with `**sql-insight:**` / `**sql-insight-cli:**` and write only what applies.
+  release-plz slices that range into each crate's CHANGELOG "Breaking Changes"
+  section; it can't route per crate, so both labels land in both changelogs. Keep
+  notes short — what changed plus the replacement; link rustdoc for usage.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -68,19 +68,29 @@ commit_parsers = [
 # ` by @user` credits the author. The PR link comes from the subject's `(#N)`,
 # which release-plz's default commit_preprocessor turns into a markdown link, so
 # it is not repeated here (squash merges put `(#N)` in the subject).
+#
+# Each breaking change is a `####` heading (its subject) plus an optional block:
+# the text wrapped between `**▼ changelog ▼**` / `**▲ changelog ▲**` in the PR
+# description (see .github/pull_request_template.md), sliced from
+# `commit.raw_message` (not `commit.body`, whose footer parsing would eat a
+# `label:` line). The block may span paragraphs and code fences and carry
+# `**sql-insight:**` / `**sql-insight-cli:**` labels. No markers → just the heading.
 body = '''
 
 ## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% set breaking = commits | filter(attribute="breaking", value=true) -%}
 {% if breaking | length > 0 %}
 ### ⚠️ Breaking Changes
-
 {% for commit in breaking %}
-{%- if commit.scope -%}
-- *({{ commit.scope }})* {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}
-{% else -%}
-- {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}
-{% endif -%}
+#### {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message }}
+{%- set parts = commit.raw_message | default(value="") | split(pat="**▼ changelog ▼**") -%}
+{%- if parts | length > 1 -%}
+{%- set note = parts | last | split(pat="**▲ changelog ▲**") | first | trim -%}
+{%- if note %}
+
+{{ note }}
+{%- endif -%}
+{%- endif %}
 {% endfor -%}
 {% endif -%}
 {% for group, group_commits in commits | group_by(attribute="group") %}

--- a/sql-insight-cli/Cargo.toml
+++ b/sql-insight-cli/Cargo.toml
@@ -10,6 +10,9 @@ include = [
     "LICENSE.txt",
 ]
 readme = "README.md"
+# Bump the MINOR by hand (pre-1.0 breaking) when the CLI's output *format* changes
+# — stdout shape or `--format json` structure — vs a value-only change (patch).
+# Manual: tooling sees the API surface, not output/behaviour.
 version = "0.2.1"
 edition = { workspace = true }
 homepage = { workspace = true }
@@ -23,6 +26,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+# A breaking sql-insight bump (one the current caret requirement won't accept)
+# means: update the requirement + bump the CLI minor by hand. Compatible bumps
+# the caret already accepts flow automatically — no CLI release.
 sql-insight = { path = "../sql-insight", version = "0.3.0", features = ["serde"] }
 clap = { version = "4.4.18", features = ["derive"] }
 rustyline = "18.0.0"

--- a/sql-insight-cli/Cargo.toml
+++ b/sql-insight-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sql-insight-cli"
 description = "A CLI utility for SQL query analysis, formatting, and transformation."
 documentation = "https://docs.rs/sql-insight-cli/"
-keywords = ["sql", "cli", "lineage", "crud", "analysis"]
+keywords = ["sql", "cli", "lineage", "crud", "normalization"]
 include = [
     "src/**/*.rs",
     "Cargo.toml",

--- a/sql-insight/Cargo.toml
+++ b/sql-insight/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sql-insight"
 description = "A utility for SQL query analysis, formatting, and transformation."
 documentation = "https://docs.rs/sql-insight/"
-keywords = ["sql", "lineage", "crud", "analysis", "query"]
+keywords = ["sql", "lineage", "crud", "analysis", "normalization"]
 include = [
     "src/**/*.rs",
     "Cargo.toml",


### PR DESCRIPTION
Repository / release tooling and docs — no library or CLI behaviour change.

### Changelog (breaking-change workflow)
- Render each breaking change as a `####` heading plus an optional free-form block, sliced from the PR description between `` `**▼ changelog ▼**` `` / `` `**▲ changelog ▲**` `` markers (read from `commit.raw_message`, so a `**label:**` line isn't parsed away as a commit footer). The block may span paragraphs and code fences and carry `**sql-insight:**` / `**sql-insight-cli:**` labels for a cross-cutting PR — the same range lands in both crates' changelogs, since the per-crate changelog template can't route content per crate.
- Add `.github/pull_request_template.md` (the marker block is commented out by default; uncomment it for a breaking change) and document the convention in `CLAUDE.md`.

### Versioning
- Document in `sql-insight-cli/Cargo.toml` when to bump the CLI version by hand: an output-*format* change is a minor (pre-1.0 breaking), a value-only change is a patch. This is manual because neither release-plz nor cargo-semver-checks detects output/behavioural changes (they see the API surface only), and a dependency-only bump cascades just a patch.

### Metadata
- Add a `normalization` keyword to both crates so the normalizer / query-fingerprinting feature surfaces in crate discovery (the keyword cap is 5, so the weakest existing keyword is dropped from each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
