### PR TITLE
feat!: upgrade sqlparser to 0.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",

--- a/sql-insight/Cargo.toml
+++ b/sql-insight/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/lib.rs"
 serde = ["dep:serde"]
 
 [dependencies]
-sqlparser = { version = "0.61.0", features = ["visitor"] }
+sqlparser = { version = "0.62.0", features = ["visitor"] }
 thiserror = "1.0.56"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 

--- a/sql-insight/src/normalizer.rs
+++ b/sql-insight/src/normalizer.rs
@@ -34,7 +34,7 @@ use std::ops::{ControlFlow, Deref};
 
 use crate::error::Error;
 use sqlparser::ast::{Expr, Insert, Statement, VisitMut, VisitorMut};
-use sqlparser::ast::{Query, SetExpr, TopQuantity, Value};
+use sqlparser::ast::{Parens, Query, SetExpr, TopQuantity, Value, ValueWithSpan};
 use sqlparser::dialect::Dialect;
 use sqlparser::parser::Parser;
 use std::ops::DerefMut;
@@ -141,9 +141,12 @@ impl VisitorMut for Normalizer {
                         row.is_empty() || row.iter().all(|expr| matches!(expr, Expr::Value(_)))
                     })
                 {
-                    *rows = vec![vec![Expr::Value(
+                    // `Values::rows` is `Vec<Parens<Vec<Expr>>>` (each row
+                    // tracks its own parentheses tokens); wrap the collapsed
+                    // sentinel row accordingly.
+                    *rows = vec![Parens::with_empty_span(vec![Expr::Value(
                         Value::Placeholder("...".into()).with_empty_span(),
-                    )]];
+                    )])];
                 }
             }
         }
@@ -164,13 +167,24 @@ impl VisitorMut for Normalizer {
             {
                 if let Some(Query { body, .. }) = source.as_deref() {
                     if let SetExpr::Values(v) = body.deref() {
+                        // `Parens` equality ignores its parenthesis tokens
+                        // (their `PartialEq` is always-equal), so this compares
+                        // the row content alone — matching the sentinel above.
                         if v.rows
-                            == vec![vec![Expr::Value(
+                            == vec![Parens::with_empty_span(vec![Expr::Value(
                                 Value::Placeholder("...".into()).with_empty_span(),
-                            )]]
+                            )])]
                         {
                             if columns.len() > 1 {
-                                columns.sort_by_key(|s| s.value.to_lowercase());
+                                // `Insert::columns` is now `Vec<ObjectName>`;
+                                // sort by the (unquoted) final identifier part,
+                                // preserving the old `Ident::value` key.
+                                columns.sort_by_key(|s| {
+                                    s.0.last()
+                                        .and_then(|p| p.as_ident())
+                                        .map(|i| i.value.to_lowercase())
+                                        .unwrap_or_default()
+                                });
                             }
                             if after_columns.len() > 1 {
                                 after_columns.sort_by_key(|s| s.value.to_lowercase());
@@ -199,13 +213,14 @@ impl VisitorMut for Normalizer {
         ControlFlow::Continue(())
     }
 
-    fn pre_visit_value(&mut self, value: &mut Value) -> ControlFlow<Self::Break> {
+    fn pre_visit_value(&mut self, value: &mut ValueWithSpan) -> ControlFlow<Self::Break> {
         // The base contract: *every* literal `Value` becomes `?`, wherever the
         // AST holds it. `pre_visit_expr` only catches an `Expr::Value`; a
         // literal kept in a bare `Value` field — `DATE '…'` / `TIMESTAMP '…'`
         // (`TypedString`), a `LIKE … ESCAPE '!'` char, a `MATCH … AGAINST '…'`
-        // search string — is reached only through this hook.
-        *value = Value::Placeholder("?".into());
+        // search string — is reached only through this hook. The visitor now
+        // hands us a `ValueWithSpan`; rewrite the inner `value`, keeping the span.
+        value.value = Value::Placeholder("?".into());
         ControlFlow::Continue(())
     }
 

--- a/sql-insight/src/reference.rs
+++ b/sql-insight/src/reference.rs
@@ -332,8 +332,18 @@ impl TableReference {
         let name = match &value.table {
             TableObject::TableName(object_name) => object_name,
             TableObject::TableFunction(function) => &function.name,
+            // Oracle `INSERT INTO (SELECT …) …`: a subquery target names no
+            // stored table, so it can't become a `TableReference`.
+            TableObject::TableQuery(_) => {
+                return Err(Error::AnalysisError(
+                    "INSERT target is a subquery, not a named table".to_string(),
+                ))
+            }
         };
-        Ok((Self::try_from_name(name)?, value.table_alias.clone()))
+        // `Insert::table_alias` is now a `TableAliasWithoutColumns`; the public
+        // pair still exposes just the alias identifier.
+        let alias = value.table_alias.as_ref().map(|a| a.alias.clone());
+        Ok((Self::try_from_name(name)?, alias))
     }
 
     /// Parse a `TableFactor::Table` into (identity, alias) pair. Other
@@ -613,5 +623,23 @@ mod tests {
         let reference = TableReference::try_from(&insert).unwrap();
         assert_eq!(reference.schema.as_ref().unwrap().value, "a");
         assert_eq!(reference.name.value, "b");
+    }
+
+    #[test]
+    fn from_insert_with_alias_extracts_the_target_alias_identifier() {
+        // `INSERT INTO t AS foo …` (PostgreSQL): the target alias is a
+        // `TableAliasWithoutColumns`. The pair keeps the base table (`t`) plus
+        // just the alias identifier (`foo`), dropping the `explicit`
+        // (`AS`-was-written) flag the analysis doesn't need.
+        use sqlparser::dialect::PostgreSqlDialect;
+        let mut stmts =
+            Parser::parse_sql(&PostgreSqlDialect {}, "INSERT INTO t AS foo (a) VALUES (1)")
+                .unwrap();
+        let Statement::Insert(insert) = stmts.remove(0) else {
+            panic!("expected an insert");
+        };
+        let (reference, alias) = TableReference::from_insert_with_alias(&insert).unwrap();
+        assert_eq!(reference.name.value, "t");
+        assert_eq!(alias.unwrap().value, "foo");
     }
 }

--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -639,6 +639,10 @@ fn alter_table_op_target_columns(op: &AlterTableOperation) -> Vec<Ident> {
         | AlterTableOperation::OwnerTo { .. }
         | AlterTableOperation::ClusterBy { .. }
         | AlterTableOperation::DropClusteringKey
+        // Redshift `ALTER SORTKEY (cols)` reorders storage; the columns are
+        // references to existing columns, not columns this op writes/creates —
+        // so, like `ClusterBy`, it names no target column.
+        | AlterTableOperation::AlterSortKey { .. }
         | AlterTableOperation::SuspendRecluster
         | AlterTableOperation::ResumeRecluster
         | AlterTableOperation::Refresh { .. }
@@ -736,7 +740,13 @@ fn join_constraint(op: &JoinOperator) -> Option<&JoinConstraint> {
         | JoinOperator::RightAnti(c)
         | JoinOperator::StraightJoin(c) => Some(c),
         JoinOperator::AsOf { constraint, .. } => Some(constraint),
-        JoinOperator::CrossApply | JoinOperator::OuterApply => None,
+        // No `ON`/`USING` predicate: APPLY correlates through the relation
+        // itself; ClickHouse `ARRAY JOIN` unnests an array expression inline.
+        JoinOperator::CrossApply
+        | JoinOperator::OuterApply
+        | JoinOperator::ArrayJoin
+        | JoinOperator::LeftArrayJoin
+        | JoinOperator::InnerArrayJoin => None,
     }
 }
 

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -15,6 +15,31 @@ impl<'a> Binder<'a> {
                 name: Some(alias.clone()),
                 expr: self.bind_expr(expr, scope),
             }],
+            // Spark `expr AS (a, b, …)`: one expression projected under several
+            // output names (e.g. `explode(arr) AS (key, value)`). Because
+            // `reads` is occurrence-based, the expression's columns must be
+            // counted exactly once — so only the first alias carries the bound
+            // expression (with its reads / lineage); the remaining aliases are
+            // extra output columns that trace to nothing, like a
+            // `(VALUES …) AS v(x)` derived column. Splitting one expression's
+            // lineage across N outputs isn't representable without re-reading
+            // it, so those tail outputs are best-effort.
+            SelectItem::ExprWithAliases { expr, aliases } => {
+                let bound = self.bind_expr(expr, scope);
+                let mut names = aliases.iter();
+                let head = NamedExpr {
+                    name: names.next().cloned(),
+                    expr: bound,
+                };
+                std::iter::once(head)
+                    .chain(names.map(|a| NamedExpr {
+                        name: Some(a.clone()),
+                        // An empty `Call` reads nothing and originates from
+                        // nothing (a `Derived` output).
+                        expr: Expr::Call { args: Vec::new() },
+                    }))
+                    .collect()
+            }
             // A wildcard isn't expanded (the rigor cost is too high for a
             // SQL-text-only library); record it so consumers know this
             // projection's column lineage is incomplete. A `REPLACE (expr AS
@@ -277,7 +302,9 @@ impl<'a> Binder<'a> {
             // resolves its own columns first, the enclosing query last.
             SqlExpr::Lambda(lambda) => self.in_lambda(
                 scope.relations.clone(),
-                lambda.params.iter().cloned(),
+                // A lambda param is now a `LambdaFunctionParameter` (name +
+                // optional type); the binder only tracks the bound name.
+                lambda.params.iter().map(|p| p.name.clone()),
                 |b| b.call([lambda.body.as_ref()], &Scope::default()),
             ),
             SqlExpr::MemberOf(member_of) => {

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -407,7 +407,9 @@ impl<'a> Binder<'a> {
     /// falling through to the correlation stack (a `(VALUES (t.a)) AS v` reads
     /// the enclosing / sibling `t.a` like a derived subquery's body).
     pub(super) fn bind_values(&mut self, values: &SqlValues) -> (LogicalPlan, Scope) {
-        let width = values.rows.iter().map(Vec::len).max().unwrap_or(0);
+        // `rows` is `Vec<Parens<Vec<Expr>>>`; each `Parens` derefs to its inner
+        // row `Vec`, so `row.len()` is the column count.
+        let width = values.rows.iter().map(|row| row.len()).max().unwrap_or(0);
         let rows: Vec<Vec<Expr>> = values
             .rows
             .iter()

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -107,6 +107,12 @@ impl<'a> Binder<'a> {
         let name = match &insert.table {
             TableObject::TableName(name) => name,
             TableObject::TableFunction(function) => &function.name,
+            // Oracle `INSERT INTO (SELECT …) …`: the target is a subquery, not a
+            // writable base table — drop + flag (like a CTE / derived target).
+            TableObject::TableQuery(query) => {
+                self.record_unsupported_dml_target("INSERT", query.as_ref());
+                return LogicalPlan::Empty;
+            }
         };
         let Some(written) = self.table_ref(name) else {
             return LogicalPlan::Empty;
@@ -153,7 +159,13 @@ impl<'a> Binder<'a> {
         // the drop + flag guard below fires rather than mis-truncating to the
         // undercounted outputs.
         let columns = if !insert.columns.is_empty() {
-            insert.columns.clone()
+            // `Insert::columns` is `Vec<ObjectName>`; a target column is named
+            // by its final identifier part (mirrors the MERGE-insert path).
+            insert
+                .columns
+                .iter()
+                .filter_map(|n| n.0.last().and_then(|p| p.as_ident().cloned()))
+                .collect()
         } else if source_wildcard {
             Vec::new()
         } else {
@@ -575,11 +587,13 @@ impl<'a> Binder<'a> {
                             } else {
                                 explicit
                             };
-                            // A MERGE INSERT is a single VALUES row.
+                            // A MERGE INSERT is a single VALUES row. Each row is
+                            // now a `Parens<Vec<Expr>>`; flatten through its
+                            // inner expressions (via `Deref`).
                             let row: Vec<Expr> = values
                                 .rows
                                 .iter()
-                                .flatten()
+                                .flat_map(|row| row.iter())
                                 .map(|e| self.bind_expr(e, &scope))
                                 .collect();
                             // Column-list-less and no catalog to fill the target
@@ -1226,7 +1240,9 @@ fn source_has_wildcard(query: &Query) -> bool {
         match body {
             SetExpr::Select(select) => select.projection.iter().any(|item| match item {
                 SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(..) => true,
-                SelectItem::UnnamedExpr(_) | SelectItem::ExprWithAlias { .. } => false,
+                SelectItem::UnnamedExpr(_)
+                | SelectItem::ExprWithAlias { .. }
+                | SelectItem::ExprWithAliases { .. } => false,
             }),
             SetExpr::Query(q) => body_has_wildcard(&q.body),
             SetExpr::SetOperation { left, right, .. } => {

--- a/sql-insight/tests/column_operation_extractor/arm_coverage.rs
+++ b/sql-insight/tests/column_operation_extractor/arm_coverage.rs
@@ -12,7 +12,10 @@ use crate::support::*;
 /// Generic parse is quirky are reshaped (`Interval` via `+`, `Subscript`
 /// on a bare identifier) or omitted (`Convert` parses its type arg as a
 /// value and drops the real column; `Interpolate` rejects a qualified
-/// name) and are left to higher-level tests.
+/// name) and are left to higher-level tests. Two arms need a non-Generic
+/// parse: `ARRAY[...]` literals (`reads_pg`, PostgreSQL) and lambda
+/// `x -> …` (`reads_duck`, DuckDB — `GenericDialect` parses `->` as the
+/// JSON-arrow operator, not a lambda).
 #[cfg(test)]
 mod expr_arm_coverage {
     use super::*;
@@ -32,6 +35,18 @@ mod expr_arm_coverage {
     fn reads_pg(sql: &str) -> Vec<ColumnRead> {
         use sql_insight::sqlparser::dialect::PostgreSqlDialect;
         extract_column_operations(&PostgreSqlDialect {}, sql)
+            .unwrap()
+            .remove(0)
+            .unwrap()
+            .reads
+    }
+
+    /// Like [`reads`], but parses under DuckDB — the built-in dialect used
+    /// for lambda `x -> …` syntax (`GenericDialect` parses `->` as the
+    /// JSON-arrow operator instead).
+    fn reads_duck(sql: &str) -> Vec<ColumnRead> {
+        use sql_insight::sqlparser::dialect::DuckDbDialect;
+        extract_column_operations(&DuckDbDialect {}, sql)
             .unwrap()
             .remove(0)
             .unwrap()
@@ -138,21 +153,30 @@ mod expr_arm_coverage {
 
     #[test]
     fn lambda() {
+        // Lambdas parse under DuckDB (`GenericDialect` reads `->` as the
+        // JSON-arrow operator, which would leak the parameter as a column).
         // A real column in the body is read; the lambda parameter is a local,
         // not a column.
         assert_unordered_eq!(
-            reads("SELECT transform(t.arr, x -> t.a) FROM t"),
+            reads_duck("SELECT transform(t.arr, x -> t.a) FROM t"),
             vec![c("arr"), c("a")]
         );
         // A bare reference to the parameter `x` adds no read (a previous
         // version wrongly read `t.x`).
         assert_unordered_eq!(
-            reads("SELECT transform(t.arr, x -> x + 1) FROM t"),
+            reads_duck("SELECT transform(t.arr, x -> x + 1) FROM t"),
             vec![c("arr")]
         );
         // Mixed: the parameter is suppressed, the real column `t.a` stays.
         assert_unordered_eq!(
-            reads("SELECT transform(t.arr, x -> x + t.a) FROM t"),
+            reads_duck("SELECT transform(t.arr, x -> x + t.a) FROM t"),
+            vec![c("arr"), c("a")]
+        );
+        // A *typed* parameter (`x INT`): sqlparser now carries an optional
+        // data type on each lambda parameter, but the binder only tracks the
+        // name — so `x` is still a local and the type `INT` is not a read.
+        assert_unordered_eq!(
+            reads_duck("SELECT transform(t.arr, x INT -> x + t.a) FROM t"),
             vec![c("arr"), c("a")]
         );
     }

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -1001,7 +1001,7 @@ mod alter_table {
     //! BOTH the old and new names — both ends of the rename are
     //! useful for downstream lineage consumers tracking column
     //! history. Schema-level operations (constraints, partitions,
-    //! RENAME TABLE) contribute no column writes.
+    //! RENAME TABLE, CLUSTER BY, SORTKEY) contribute no column writes.
     use super::*;
 
     #[test]
@@ -1084,6 +1084,24 @@ mod alter_table {
         // surface (the table itself stays in table_op writes).
         assert_column_ops(
             "ALTER TABLE t ADD CONSTRAINT uq UNIQUE (a)",
+            ColumnOperation {
+                statement_kind: StatementKind::AlterTable,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn alter_table_alter_sort_key_emits_no_column_writes() {
+        // Redshift `ALTER SORTKEY (cols)` reorders storage and only
+        // references existing columns — like ADD CONSTRAINT / CLUSTER BY
+        // it's schema-level, so no column writes surface (the table itself
+        // stays in table_op writes).
+        assert_column_ops(
+            "ALTER TABLE t ALTER SORTKEY (a, b)",
             ColumnOperation {
                 statement_kind: StatementKind::AlterTable,
                 reads: vec![],

--- a/sql-insight/tests/column_operation_extractor/diagnostics.rs
+++ b/sql-insight/tests/column_operation_extractor/diagnostics.rs
@@ -2,7 +2,7 @@ use crate::support::*;
 
 mod reported {
     use super::*;
-    use sql_insight::sqlparser::dialect::BigQueryDialect;
+    use sql_insight::sqlparser::dialect::{BigQueryDialect, OracleDialect};
 
     #[test]
     fn unsupported_statement_reports_diagnostic() {
@@ -43,6 +43,25 @@ mod reported {
             "UPDATE (SELECT 1) x SET a = 1",
             ColumnOperation {
                 statement_kind: StatementKind::Update,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn insert_into_subquery_target_reports_diagnostic() {
+        // Oracle `INSERT INTO (SELECT …) …`: the target is a subquery, not a
+        // writable base table — flagged (like the non-table UPDATE / MERGE
+        // target above), not dropped silently. The statement_kind stays Insert;
+        // nothing is written. (`OracleDialect` parses the subquery target.)
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a FROM t) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
                 reads: vec![],
                 writes: vec![],
                 lineage: vec![],

--- a/sql-insight/tests/column_operation_extractor/joins_sets.rs
+++ b/sql-insight/tests/column_operation_extractor/joins_sets.rs
@@ -898,4 +898,39 @@ mod join_arm_coverage {
             vec![read("t", "a"), read("u", "id")]
         );
     }
+
+    // ClickHouse `ARRAY JOIN` (and its `LEFT` / `INNER` forms) unnest an array
+    // expression inline and carry no `ON` predicate (join_constraint → None,
+    // like CROSS APPLY). The array expression is not itself a scanned relation,
+    // so only the projection's `t.a` surfaces. `GenericDialect` parses all
+    // three forms.
+    #[test]
+    fn array_join() {
+        assert_unordered_eq!(
+            join_reads("SELECT t.a FROM t ARRAY JOIN t.arr", &GenericDialect {}),
+            vec![read("t", "a")]
+        );
+    }
+
+    #[test]
+    fn left_array_join() {
+        assert_unordered_eq!(
+            join_reads(
+                "SELECT t.a FROM t LEFT ARRAY JOIN t.arr",
+                &GenericDialect {}
+            ),
+            vec![read("t", "a")]
+        );
+    }
+
+    #[test]
+    fn inner_array_join() {
+        assert_unordered_eq!(
+            join_reads(
+                "SELECT t.a FROM t INNER ARRAY JOIN t.arr",
+                &GenericDialect {}
+            ),
+            vec![read("t", "a")]
+        );
+    }
 }

--- a/sql-insight/tests/column_operation_extractor/lineage.rs
+++ b/sql-insight/tests/column_operation_extractor/lineage.rs
@@ -50,6 +50,27 @@ mod projections {
     }
 
     #[test]
+    fn expr_with_multi_column_aliases_binds_the_expression_once() {
+        // Spark `expr AS (a, b, …)`: one expression projected under several
+        // output names. `reads` is occurrence-based, so `t.arr` is read exactly
+        // once; the expression's lineage attaches to the first alias (`k`), and
+        // the tail alias (`v`) is an extra output that traces to nothing —
+        // splitting one expression's lineage across N outputs isn't
+        // representable without re-reading it. (`GenericDialect` parses the
+        // multi-column alias.)
+        assert_column_ops(
+            "SELECT explode(t.arr) AS (k, v) FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "arr")],
+                writes: vec![],
+                lineage: vec![transformation(col("t", "arr"), out("k", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn in_subquery_in_value_position_flows_lhs_not_the_subquery() {
         // `a IN (subquery)` projected as a value: the LHS `a` flows to the
         // output (a boolean transformation of it, symmetric with `a IN (list)`);
@@ -771,6 +792,15 @@ mod cte_derived_rename {
 
 mod lambda {
     use super::*;
+    use sql_insight::sqlparser::dialect::DuckDbDialect;
+
+    /// Lambdas need a lambda-aware dialect: `GenericDialect` (used by the
+    /// default `assert_column_ops`) parses `x -> …` as the JSON-arrow
+    /// operator, so the parameter would leak as a column read. DuckDB parses
+    /// it as a real `Lambda`, exercising the binder's lambda-scoping path.
+    fn assert_lambda_ops(sql: &str, expected: ColumnOperation) {
+        assert_column_ops_with_dialect(&DuckDbDialect {}, sql, expected);
+    }
 
     #[test]
     fn lambda_param_is_not_traced_into_a_same_named_derived_column() {
@@ -779,7 +809,7 @@ mod lambda {
         // `s.x`. Only the array argument (`arr` → `s.arr`) flows to the output.
         // (A `Derived` binding instead of a dedicated `Local` would mis-trace
         // `x` into the derived subquery and emit a spurious `s.x → r`.)
-        assert_column_ops(
+        assert_lambda_ops(
             "SELECT transform(arr, x -> x) AS r FROM (SELECT arr, x FROM s) d",
             ColumnOperation {
                 statement_kind: StatementKind::Select,
@@ -799,7 +829,7 @@ mod lambda {
         // in the resolution stack and doesn't over-shadow an inner scope. Both
         // the array arg (`t1.arr`) and the body value (`t2.x`) flow to the
         // anonymous output as a transformation.
-        assert_column_ops(
+        assert_lambda_ops(
             "SELECT transform(arr, x -> (SELECT x FROM t2)) FROM t1",
             ColumnOperation {
                 statement_kind: StatementKind::Select,
@@ -820,7 +850,7 @@ mod lambda {
         // scope, so a bare `x` resolves to `t3.x`. A flat "parameter checked
         // first" rule would have wrongly shadowed both `t2` and `t3`; the frame
         // stack places the parameter at its correct depth.
-        assert_column_ops(
+        assert_lambda_ops(
             "SELECT transform(arr, x -> (SELECT (SELECT x FROM t3) FROM t2)) FROM t1",
             ColumnOperation {
                 statement_kind: StatementKind::Select,
@@ -842,7 +872,7 @@ mod lambda {
         // (→ s.k), shadowing the lambda parameter — the parameter is not a false
         // read. Both the array arg (`t1.arr`) and the body value (`s.k`, through
         // the CTE) flow to the anonymous output.
-        assert_column_ops(
+        assert_lambda_ops(
             "SELECT transform(arr, x -> (WITH c AS (SELECT k AS x FROM s) SELECT x FROM c)) FROM t1",
             ColumnOperation {
                 statement_kind: StatementKind::Select,

--- a/sql-insight/tests/normalizer.rs
+++ b/sql-insight/tests/normalizer.rs
@@ -203,6 +203,41 @@ fn test_do_not_alphabetize_insert_columns_when_values_not_unified() {
 }
 
 #[test]
+fn test_alphabetize_insert_columns_is_case_insensitive_and_preserves_case() {
+    // The sort key is the column name lowercased, so `B` orders before `C` but
+    // after `a`; the written case (`B`, `C`) is preserved in the output. Each
+    // column is now an `ObjectName`, keyed on its final identifier part.
+    let sql = "INSERT INTO t1 (B, a, C) VALUES (1, 2, 3)";
+    let expected = vec!["INSERT INTO t1 (a, B, C) VALUES (...)".into()];
+    assert_normalize(
+        sql,
+        expected,
+        all_dialects(),
+        NormalizerOptions::new()
+            .with_unify_values(true)
+            .with_alphabetize_insert_columns(true),
+    );
+}
+
+#[test]
+fn test_alphabetize_insert_columns_sorts_quoted_by_unquoted_value() {
+    // A quoted column sorts by its *unquoted* identifier value (`"Z"` → `z`,
+    // ordering last), not by its rendered form (which would sort the `"` before
+    // letters and place it first); the quotes are preserved in the output.
+    // `"…"`-quoting is the GenericDialect's identifier quote.
+    let sql = r#"INSERT INTO t1 ("Z", a, m) VALUES (1, 2, 3)"#;
+    let expected = vec![r#"INSERT INTO t1 (a, m, "Z") VALUES (...)"#.into()];
+    assert_normalize(
+        sql,
+        expected,
+        vec![Box::new(sql_insight::sqlparser::dialect::GenericDialect {})],
+        NormalizerOptions::new()
+            .with_unify_values(true)
+            .with_alphabetize_insert_columns(true),
+    );
+}
+
+#[test]
 fn test_typed_string_literal_value_is_normalized() {
     // A `DATE` / `TIMESTAMP '…'` literal is a `TypedString`, whose value is a
     // bare `Value` field (not an `Expr::Value`) — it must still normalize so


### PR DESCRIPTION
## Summary

Upgrades `sqlparser` 0.61 → 0.62 and adapts the resolver/normalizer to its AST
changes. Beyond keeping the build green, this makes sql-insight analyze several
constructs 0.62 can now parse:

- ClickHouse `ARRAY JOIN` / `LEFT ARRAY JOIN` / `INNER ARRAY JOIN`
- Redshift `ALTER SORTKEY (cols)` (schema-level; no column writes)
- Spark multi-column aliases `expr AS (a, b)` (best-effort: reads counted once,
  lineage to the first alias)
- Oracle subquery INSERT targets `INSERT INTO (SELECT …) …` (flagged as an
  unsupported write target, dropped)

Internal adaptations: `Parens`-wrapped VALUES rows, `ObjectName` INSERT columns,
`TableAliasWithoutColumns`, `LambdaFunctionParameter`, and the
`pre_visit_value(&mut ValueWithSpan)` visitor signature.

New tests: ARRAY JOIN arm coverage (×3), Spark multi-alias lineage, ALTER SORTKEY
no-column-writes, Oracle subquery-INSERT diagnostic, typed lambda parameter,
case-insensitive / quoted INSERT-column alphabetization, aliased-INSERT target.
Lambda tests moved from `GenericDialect` to `DuckDbDialect` (see the breaking note
below).

## Breaking changes (reference for the release-PR CHANGELOG note)

- The re-exported `sqlparser` moves 0.61 → 0.62. It's part of the public API
  (`pub use sqlparser`; its AST types appear in `TableReference`, extractor
  inputs, and `&dyn Dialect`), so consumers must upgrade too. AST types you may
  touch changed — e.g. `Insert::columns` is now `Vec<ObjectName>` (was
  `Vec<Ident>`), `Values::rows` is `Vec<Parens<Vec<Expr>>>`, literals are
  `ValueWithSpan`, lambda params are `LambdaFunctionParameter`.
- Under `GenericDialect`, `->` is now a binary operator, not a lambda arrow
  (upstream revert of an accidental enablement). Lambda syntax (`x -> …`) needs a
  lambda-aware dialect such as `DuckDbDialect` / `DatabricksDialect`.

## Deferred to follow-up PRs

- Fan-out lineage for `expr AS (a, b, …)` — emit an edge to every alias, not just
  the first (needs a one-expr → N-outputs model change).
- Resolve Oracle `INSERT INTO (subquery)` through to its base table as the write
  target, instead of dropping it.
- Stop surfacing a ClickHouse `ARRAY JOIN` array operand as a (spurious) table read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
