### PR TITLE
chore: drop the per-PR changelog block

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,24 +8,3 @@ set, an incompatible API):
 Below → the squash commit body: what changed and why (the title already
 summarizes, so add context only if it helps).
 -->
-
-
-
-<!--
-Breaking change? Mark the PR title with `!`, then uncomment the block below
-(remove the comment markers wrapping it) and fill the crate label(s) that apply —
-delete the one you don't use. Keep it short: what changed and the replacement;
-link to the docs for how to use it. Only this range is copied into the changelog's
-"Breaking Changes" section (it lands in both crates' changelogs, so readers pick
-their part). Paragraphs and code fences are fine.
--->
-
-<!--
-**▼ changelog ▼**
-
-**sql-insight:**
-
-**sql-insight-cli:**
-
-**▲ changelog ▲**
--->

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -67,12 +67,8 @@ commit_parsers = [
 # which release-plz's default commit_preprocessor turns into a markdown link, so
 # it is not repeated here (squash merges put `(#N)` in the subject).
 #
-# Each breaking change is a `####` heading (its subject) plus an optional block:
-# the text wrapped between `**▼ changelog ▼**` / `**▲ changelog ▲**` in the PR
-# description (see .github/pull_request_template.md), sliced from
-# `commit.raw_message` (not `commit.body`, whose footer parsing would eat a
-# `label:` line). The block may span paragraphs and code fences and carry
-# `**sql-insight:**` / `**sql-insight-cli:**` labels. No markers → just the heading.
+# Each breaking change is a `####` heading (its subject) only; migration notes,
+# if any, are written by hand when reviewing the release PR's CHANGELOG.md.
 body = '''
 
 ## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
@@ -81,14 +77,6 @@ body = '''
 ### ⚠️ Breaking Changes
 {% for commit in breaking %}
 #### {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message }}
-{%- set parts = commit.raw_message | default(value="") | split(pat="**▼ changelog ▼**") -%}
-{%- if parts | length > 1 -%}
-{%- set note = parts | last | split(pat="**▲ changelog ▲**") | first | trim -%}
-{%- if note %}
-
-{{ note }}
-{%- endif -%}
-{%- endif %}
 {% endfor -%}
 {% endif -%}
 {% for group, group_commits in commits | group_by(attribute="group") %}


### PR DESCRIPTION
## Summary

Removes the per-PR changelog block (`**▼ changelog ▼**` … `**▲ changelog ▲**`)
from the PR template, and the matching note-slicing from `release-plz.toml`.

Rationale: release-plz already opens a **Release PR** whose `CHANGELOG.md` is the
review point before publishing, so breaking-change migration notes can be written
there — by one author, at release time — instead of per-PR (which varied in
quality and needed an easy-to-forget uncomment/fill step).

What stays: the `!` in the title still flags breaking changes, and release-plz
still lists them by subject under "⚠️ Breaking Changes". Only the per-PR
free-text note mechanism is dropped.

Verified with `git-cliff --config release-plz.toml`: the body template still
renders with no new error (the `date`-on-`Unreleased` error is pre-existing and
identical on master — release-plz supplies the timestamp at release time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
