### PR TITLE
fix: don't surface a ClickHouse ARRAY JOIN operand as a table read

### DIFF
--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -787,6 +787,17 @@ fn join_is_natural(op: &JoinOperator) -> bool {
     matches!(join_constraint(op), Some(JoinConstraint::Natural))
 }
 
+/// Whether a join operator is a ClickHouse `ARRAY JOIN` / `LEFT ARRAY JOIN` /
+/// `INNER ARRAY JOIN` — which unnests an array expression inline rather than
+/// joining a relation, so its operand is a column expression, not a scanned
+/// table.
+fn is_array_join(op: &JoinOperator) -> bool {
+    matches!(
+        op,
+        JoinOperator::ArrayJoin | JoinOperator::LeftArrayJoin | JoinOperator::InnerArrayJoin
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -544,7 +544,14 @@ impl<'a> Binder<'a> {
             // A joined LATERAL factor sees the left siblings plus the join
             // inputs accumulated so far.
             let visible: Vec<Relation> = left.iter().chain(&scope.relations).cloned().collect();
-            let (right, right_scope) = self.bind_table_factor(&j.relation, &visible);
+            // ClickHouse `ARRAY JOIN`'s operand is an array column being
+            // unnested, not a scanned table — bind it against the visible
+            // relations so it reads a column, not a table.
+            let (right, right_scope) = if is_array_join(&j.join_operator) {
+                self.bind_array_join(&j.relation, &visible)
+            } else {
+                self.bind_table_factor(&j.relation, &visible)
+            };
             // Merge columns — an unqualified reference to one fans in to both
             // sides. An explicit `USING (col)` names them; a NATURAL join takes
             // the two sides' schema-common columns (so it needs a catalog —
@@ -563,6 +570,78 @@ impl<'a> Binder<'a> {
                 .collect();
             node = join(node, right, on);
         }
+        (node, scope)
+    }
+
+    /// Bind a ClickHouse `ARRAY JOIN <operand> [AS alias]` right side. sqlparser
+    /// parses the operand as a `TableFactor::Table`, but it is an array
+    /// *expression* (typically a column of a visible relation) being unnested —
+    /// not a scanned table. Resolve its name as a column read against `visible`
+    /// and bind it as an opaque unnest (a [`TableFunction`], so no table read),
+    /// exposing the unnested output under its alias / column name.
+    pub(super) fn bind_array_join(
+        &mut self,
+        factor: &TableFactor,
+        visible: &[Relation],
+    ) -> (LogicalPlan, Scope) {
+        let (args, alias_name) = match factor {
+            // `ARRAY JOIN f(args) [AS m]`: an array-producing *expression* (e.g.
+            // `arrayMap(…)`). Its argument expressions carry the reads — the
+            // function name is not a column — and the unnested output is the
+            // alias, if any.
+            TableFactor::Table {
+                alias,
+                args: Some(fn_args),
+                ..
+            } => {
+                let bound =
+                    self.bind_function_arg_list(&fn_args.args, &Scope::from_relations(visible));
+                (bound, alias.as_ref().map(|a| a.name.clone()))
+            }
+            // `ARRAY JOIN arr [AS x]` / `ARRAY JOIN t.arr`: a plain array
+            // *column*. Read its name as a column of the visible relations.
+            TableFactor::Table { name, alias, .. } => {
+                let parts: Vec<Ident> = name
+                    .0
+                    .iter()
+                    .filter_map(|p| p.as_ident().cloned())
+                    .collect();
+                // The unnested output takes the explicit alias, else the
+                // operand's own (last) name — so a later `arr` reference resolves
+                // to the unnested element, not the source array.
+                let alias_name = alias
+                    .as_ref()
+                    .map(|a| a.name.clone())
+                    .or_else(|| parts.last().cloned());
+                let args = if parts.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![self.resolve_expr(&parts, &Scope::from_relations(visible))]
+                };
+                (args, alias_name)
+            }
+            // Any other factor shape (a derived subquery, nested join, …) is not
+            // valid ClickHouse ARRAY JOIN syntax, but sqlparser accepts it — bind
+            // it through the normal factor path (best-effort: keep its reads and
+            // alias) rather than silently dropping it.
+            _ => return self.bind_table_factor(factor, visible),
+        };
+        let node = LogicalPlan::TableFunction(TableFunction {
+            alias: alias_name.clone(),
+            input: Box::new(LogicalPlan::Empty),
+            args,
+        });
+        // Expose the unnested output as a synthetic (Derived) column so a
+        // reference to it (`x` / `arr`) binds to the unnest — not falling through
+        // to a real table as a phantom column — and traces to a synthetic source
+        // (dropped from reads), never to the source array as a second read.
+        let scope = match alias_name {
+            Some(name) => Scope::single(Relation::Derived {
+                alias: None,
+                columns: vec![name],
+            }),
+            None => Scope::default(),
+        };
         (node, scope)
     }
 

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -391,7 +391,14 @@ impl<'a> Binder<'a> {
         // both computed before the right scope is absorbed — so an unqualified
         // reference resolves to both sides instead of staying `Ambiguous`.
         for j in joins {
-            let (node, jscope) = self.bind_table_factor(&j.relation, &scope.relations);
+            // An ARRAY JOIN operand is an unnested array column, not a joined
+            // table (same special case as `bind_table_with_joins`).
+            let (node, jscope) = if is_array_join(&j.join_operator) {
+                let visible = scope.relations.clone();
+                self.bind_array_join(&j.relation, &visible)
+            } else {
+                self.bind_table_factor(&j.relation, &scope.relations)
+            };
             let merge = if join_is_natural(&j.join_operator) {
                 self.natural_merge_columns(&scope, &jscope)
             } else {

--- a/sql-insight/tests/column_operation_extractor/joins_sets.rs
+++ b/sql-insight/tests/column_operation_extractor/joins_sets.rs
@@ -900,15 +900,16 @@ mod join_arm_coverage {
     }
 
     // ClickHouse `ARRAY JOIN` (and its `LEFT` / `INNER` forms) unnest an array
-    // expression inline and carry no `ON` predicate (join_constraint → None,
-    // like CROSS APPLY). The array expression is not itself a scanned relation,
-    // so only the projection's `t.a` surfaces. `GenericDialect` parses all
-    // three forms.
+    // *column* inline and carry no `ON` predicate (join_constraint → None, like
+    // CROSS APPLY). The operand is not a scanned table (so it is NOT a table
+    // read) but a column of the left relation — so `t.arr` surfaces as a column
+    // read alongside the projection's `t.a`. `GenericDialect` parses all three
+    // forms.
     #[test]
     fn array_join() {
         assert_unordered_eq!(
             join_reads("SELECT t.a FROM t ARRAY JOIN t.arr", &GenericDialect {}),
-            vec![read("t", "a")]
+            vec![read("t", "a"), read("t", "arr")]
         );
     }
 
@@ -919,7 +920,7 @@ mod join_arm_coverage {
                 "SELECT t.a FROM t LEFT ARRAY JOIN t.arr",
                 &GenericDialect {}
             ),
-            vec![read("t", "a")]
+            vec![read("t", "a"), read("t", "arr")]
         );
     }
 
@@ -930,7 +931,35 @@ mod join_arm_coverage {
                 "SELECT t.a FROM t INNER ARRAY JOIN t.arr",
                 &GenericDialect {}
             ),
-            vec![read("t", "a")]
+            vec![read("t", "a"), read("t", "arr")]
+        );
+    }
+
+    #[test]
+    fn array_join_alias_does_not_leak_as_a_phantom_column() {
+        // `AS x` names the unnested element (a synthetic column), not a column
+        // of `t` — so `x` in the projection is not a phantom `t.x` read; only
+        // the real `t.c` and the unnested source `t.arr` surface.
+        assert_unordered_eq!(
+            join_reads(
+                "SELECT x, t.c FROM t ARRAY JOIN t.arr AS x",
+                &GenericDialect {}
+            ),
+            vec![read("t", "c"), read("t", "arr")]
+        );
+    }
+
+    #[test]
+    fn array_join_expression_operand_reads_its_arguments() {
+        // `ARRAY JOIN f(args)` is an array-producing *expression*: its argument
+        // columns are the reads. The function name is neither a table nor a
+        // column, so only `t.a` / `t.b` surface — not a phantom `t.arrayConcat`.
+        assert_unordered_eq!(
+            join_reads(
+                "SELECT m FROM t ARRAY JOIN arrayConcat(t.a, t.b) AS m",
+                &GenericDialect {}
+            ),
+            vec![read("t", "a"), read("t", "b")]
         );
     }
 }

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -66,6 +66,69 @@ mod basic {
     }
 
     #[test]
+    fn array_join_operand_is_not_a_read_table() {
+        // ClickHouse `ARRAY JOIN arr` unnests an array *column* of `t`.
+        // sqlparser parses the operand as a table factor, but it is not a
+        // scanned table — so only `t` is a read table, never a phantom `arr`.
+        // (`GenericDialect` parses ARRAY JOIN; not all dialects do.)
+        let sql = "SELECT s FROM t ARRAY JOIN arr";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![],
+            read_tables: vec![cread(table("t"))],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(
+            sql,
+            expected,
+            vec![Box::new(sql_insight::sqlparser::dialect::GenericDialect {})],
+        );
+    }
+
+    #[test]
+    fn array_join_derived_operand_keeps_its_reads() {
+        // Not valid ClickHouse, but sqlparser parses a derived subquery as the
+        // ARRAY JOIN operand — it falls back to the normal factor path
+        // (best-effort), so the subquery's `u` read survives instead of being
+        // silently dropped.
+        let sql = "SELECT s FROM t ARRAY JOIN (SELECT arr FROM u) AS x";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![],
+            read_tables: vec![cread(table("t")), cread(table("u"))],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(
+            sql,
+            expected,
+            vec![Box::new(sql_insight::sqlparser::dialect::GenericDialect {})],
+        );
+    }
+
+    #[test]
+    fn update_array_join_operand_is_not_a_read_table() {
+        // The UPDATE target's join clause takes the same ARRAY JOIN special
+        // case as SELECT: the operand is `t`'s array column, not a table — so
+        // no phantom `arr` read table. Reading `t.arr` references the write
+        // target's own data, so `t` itself surfaces as a read.
+        let sql = "UPDATE t ARRAY JOIN arr SET a = 1";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![],
+            read_tables: vec![cread(table("t"))],
+            update_tables: vec![cwrite(table("t"))],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(
+            sql,
+            expected,
+            vec![Box::new(sql_insight::sqlparser::dialect::GenericDialect {})],
+        );
+    }
+
+    #[test]
     fn test_multiple_statements() {
         let sql = "SELECT a FROM t1; SELECT b FROM t2";
         let expected = vec![


### PR DESCRIPTION
## Summary

Fixes a follow-up noted in #55: a ClickHouse `ARRAY JOIN` operand was surfaced as
a (spurious) table read.

sqlparser parses the operand of `ARRAY JOIN` / `LEFT ARRAY JOIN` / `INNER ARRAY
JOIN` as a `TableFactor::Table`, indistinguishable from a real table — so
`SELECT s FROM t ARRAY JOIN arr` reported a phantom read of a table `arr`.
(ClickHouse's ARRAY JOIN operand is always an array — a column or an array
expression — never a table.)

This binds the ARRAY JOIN operand as an opaque unnest (a `TableFunction`, so no
table read):

- A plain array **column** (`arr` / `t.arr`) reads as a column of the left
  relation: `read_tables` no longer includes it (`SELECT s FROM t ARRAY JOIN arr`
  → `[t]`, not `[t, arr]`), and `t.arr` surfaces as a column read.
- An array **expression** (`arrayConcat(t.a, t.b)`) reads its argument columns
  (`t.a`, `t.b`) — not the function name.
- The unnested output (`AS x`, else the operand's own name) is exposed as a
  synthetic column, so a reference to it no longer leaks as a phantom `t.x` read.

Edge cases covered on review:

- The **UPDATE target's join clause** takes the same special case:
  `UPDATE t ARRAY JOIN arr SET a = 1` no longer reads a phantom `arr` table
  (and `t` correctly surfaces as a read — the unnest references the write
  target's own data).
- A **non-Table operand** (a derived subquery — invalid ClickHouse but sqlparser
  parses it) falls back to the normal factor path, so its reads survive instead
  of being silently dropped.
- Pipe joins (`|> JOIN`) cannot parse an ARRAY JOIN operator — unreachable.

Tests: updated the ARRAY JOIN arm coverage (now expects the operand column read),
plus table-level "operand is not a read table" (SELECT and UPDATE), "alias does
not leak as a phantom column", "expression operand reads its arguments", and
"derived operand keeps its reads" tests. All gates green (fmt / clippy /
`test --all` / doc).

Left as-is (both exotic): the analogous multi-table DELETE-target path
(`DELETE … USING t ARRAY JOIN arr`), and a multi-array `ARRAY JOIN a, b` — which
sqlparser parses as a comma-join, so `b` still looks like a table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
