### PR TITLE
feat: resolve Oracle inline-view INSERT targets to their base table

### DIFF
--- a/sql-insight/src/reference.rs
+++ b/sql-insight/src/reference.rs
@@ -9,7 +9,10 @@ use core::fmt;
 
 use crate::casing::IdentifierCasing;
 use crate::error::Error;
-use sqlparser::ast::{Ident, Insert, ObjectName, TableFactor, TableObject};
+use sqlparser::ast::{
+    GroupByExpr, Ident, Insert, ObjectName, Query, Select, SelectFlavor, SetExpr, TableFactor,
+    TableObject,
+};
 
 /// Physical table identity — the `catalog.schema.name` triplet.
 ///
@@ -327,18 +330,22 @@ impl TableReference {
         }
     }
 
-    /// Parse an INSERT statement's target into (identity, alias) pair.
+    /// Parse an INSERT statement's target into (identity, alias) pair. An
+    /// Oracle inline-view target (`INSERT INTO (SELECT … FROM t) …`) resolves
+    /// through to its single base table; a view over no single base table (a
+    /// join, a set operation) surfaces as an `AnalysisError`.
     pub(crate) fn from_insert_with_alias(value: &Insert) -> Result<(Self, Option<Ident>), Error> {
         let name = match &value.table {
             TableObject::TableName(object_name) => object_name,
             TableObject::TableFunction(function) => &function.name,
-            // Oracle `INSERT INTO (SELECT …) …`: a subquery target names no
-            // stored table, so it can't become a `TableReference`.
-            TableObject::TableQuery(_) => {
-                return Err(Error::AnalysisError(
-                    "INSERT target is a subquery, not a named table".to_string(),
-                ))
-            }
+            TableObject::TableQuery(query) => match insert_target_view(query) {
+                Some((name, _)) => name,
+                None => {
+                    return Err(Error::AnalysisError(
+                        "INSERT target is a subquery over no single base table".to_string(),
+                    ))
+                }
+            },
         };
         // `Insert::table_alias` is now a `TableAliasWithoutColumns`; the public
         // pair still exposes just the alias identifier.
@@ -563,6 +570,94 @@ impl TryFrom<&ObjectName> for TableReference {
     }
 }
 
+/// See through an Oracle inline-view INSERT target
+/// (`INSERT INTO (SELECT … FROM t [WHERE …]) …`) to its single base table:
+/// the `SELECT`'s one plain-table FROM item. Only the minimal insertable-view
+/// shape passes — a projection, the single FROM table, and an optional WHERE.
+/// `None` for everything else: a join / set operation / non-table factor
+/// names no single base table SQL text can determine (Oracle's key-preserved
+/// rules need a catalog), and any other clause (GROUP BY / HAVING / DISTINCT /
+/// ORDER BY / FETCH / CONNECT BY / …) makes the view non-insertable — and
+/// could carry column references that would otherwise drop silently. The
+/// returned [`Select`] carries the projection (the insertable target columns)
+/// and the WHERE predicate for the caller. Both destructures are exhaustive,
+/// so a new `Query` / `Select` clause forces a keep-or-reject decision here.
+pub(crate) fn insert_target_view(query: &Query) -> Option<(&ObjectName, &Select)> {
+    let Query {
+        with: None,
+        body,
+        order_by: None,
+        limit_clause: None,
+        fetch: None,
+        locks,
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+        pipe_operators,
+    } = query
+    else {
+        return None;
+    };
+    if !locks.is_empty() || !pipe_operators.is_empty() {
+        return None;
+    }
+    let SetExpr::Select(select) = body.as_ref() else {
+        return None;
+    };
+    let Select {
+        select_token: _,
+        optimizer_hints: _,
+        distinct: None,
+        select_modifiers: None,
+        top: None,
+        top_before_distinct: _,
+        projection: _,
+        exclude: None,
+        into: None,
+        from,
+        lateral_views,
+        prewhere: None,
+        selection: _,
+        connect_by,
+        group_by: GroupByExpr::Expressions(group_by, group_by_modifiers),
+        cluster_by,
+        distribute_by,
+        sort_by,
+        having: None,
+        named_window,
+        qualify: None,
+        window_before_qualify: _,
+        value_table_mode: None,
+        flavor: SelectFlavor::Standard,
+    } = select.as_ref()
+    else {
+        return None;
+    };
+    if !group_by.is_empty()
+        || !group_by_modifiers.is_empty()
+        || !cluster_by.is_empty()
+        || !distribute_by.is_empty()
+        || !sort_by.is_empty()
+        || !lateral_views.is_empty()
+        || !connect_by.is_empty()
+        || !named_window.is_empty()
+    {
+        return None;
+    }
+    let [from] = from.as_slice() else {
+        return None;
+    };
+    if !from.joins.is_empty() {
+        return None;
+    }
+    match &from.relation {
+        TableFactor::Table {
+            name, args: None, ..
+        } => Some((name, select)),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -641,5 +736,28 @@ mod tests {
         let (reference, alias) = TableReference::from_insert_with_alias(&insert).unwrap();
         assert_eq!(reference.name.value, "t");
         assert_eq!(alias.unwrap().value, "foo");
+    }
+
+    #[test]
+    fn try_from_insert_sees_through_an_inline_view_target() {
+        // Oracle `INSERT INTO (SELECT … FROM s.t) …` resolves to the view's
+        // single base table; a join view has no single base table → error.
+        use sqlparser::dialect::OracleDialect;
+        let parse = |sql: &str| {
+            let mut stmts = Parser::parse_sql(&OracleDialect {}, sql).unwrap();
+            let Statement::Insert(insert) = stmts.remove(0) else {
+                panic!("expected an insert");
+            };
+            insert
+        };
+        let insert = parse("INSERT INTO (SELECT a FROM s.t WHERE a > 0) VALUES (1)");
+        let reference = TableReference::try_from(&insert).unwrap();
+        assert_eq!(reference.schema.as_ref().unwrap().value, "s");
+        assert_eq!(reference.name.value, "t");
+        let join = parse("INSERT INTO (SELECT a.id FROM a JOIN b ON a.id = b.id) VALUES (1)");
+        assert!(matches!(
+            TableReference::try_from(&join),
+            Err(Error::AnalysisError(_))
+        ));
     }
 }

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -104,15 +104,22 @@ impl<'a> Binder<'a> {
     /// expression is dropped (not flagged: it isn't an analyzable-info loss the
     /// common, constant case would false-alarm on).
     pub(super) fn bind_insert(&mut self, insert: &SqlInsert) -> LogicalPlan {
-        let name = match &insert.table {
-            TableObject::TableName(name) => name,
-            TableObject::TableFunction(function) => &function.name,
-            // Oracle `INSERT INTO (SELECT …) …`: the target is a subquery, not a
-            // writable base table — drop + flag (like a CTE / derived target).
-            TableObject::TableQuery(query) => {
-                self.record_unsupported_dml_target("INSERT", query.as_ref());
-                return LogicalPlan::Empty;
-            }
+        let (name, view) = match &insert.table {
+            TableObject::TableName(name) => (name, None),
+            TableObject::TableFunction(function) => (&function.name, None),
+            // Oracle `INSERT INTO (SELECT …) …`: an inline-view target — the
+            // row lands in the view's single base table, so resolve through to
+            // it (the projection names the target columns, the WHERE is filter
+            // reads). A view over no single base table (a join — key-preserved
+            // rules need a catalog — or a set operation) is dropped + flagged
+            // like a CTE / derived target.
+            TableObject::TableQuery(query) => match crate::reference::insert_target_view(query) {
+                Some((name, select)) => (name, Some(select)),
+                None => {
+                    self.record_unsupported_dml_target("INSERT", query.as_ref());
+                    return LogicalPlan::Empty;
+                }
+            },
         };
         let Some(written) = self.table_ref(name) else {
             return LogicalPlan::Empty;
@@ -146,7 +153,8 @@ impl<'a> Binder<'a> {
             .source
             .as_ref()
             .is_some_and(|q| source_has_wildcard(q));
-        // The written column list: an explicit `(a, b)` wins; otherwise a
+        // The written column list: an explicit list wins — an `(a, b)` list, or
+        // an inline-view target's plain-column projection — otherwise a
         // column-less INSERT fills from the target's catalog columns (reusing
         // the `table_match` list above), truncated to the source's projected
         // arity. The catalog columns are kept in their canonical form (quoted as
@@ -158,7 +166,7 @@ impl<'a> Binder<'a> {
         // catalog columns can't be positionally paired: leave the list empty so
         // the drop + flag guard below fires rather than mis-truncating to the
         // undercounted outputs.
-        let columns = if !insert.columns.is_empty() {
+        let explicit: Vec<Ident> = if !insert.columns.is_empty() {
             // `Insert::columns` is `Vec<ObjectName>`; a target column is named
             // by its final identifier part (mirrors the MERGE-insert path).
             insert
@@ -166,6 +174,12 @@ impl<'a> Binder<'a> {
                 .iter()
                 .filter_map(|n| n.0.last().and_then(|p| p.as_ident().cloned()))
                 .collect()
+        } else {
+            view.map(view_target_columns).unwrap_or_default()
+        };
+        let has_explicit = !explicit.is_empty();
+        let columns = if has_explicit {
+            explicit
         } else if source_wildcard {
             Vec::new()
         } else {
@@ -198,7 +212,7 @@ impl<'a> Binder<'a> {
             }
         };
         if let Some(source_count) = source_count {
-            if !insert.columns.is_empty() {
+            if has_explicit {
                 // An explicit list must match the source exactly — either
                 // direction silently zips to the shorter side.
                 self.diagnose_insert_arity(&target, true, columns.len(), source_count);
@@ -214,6 +228,23 @@ impl<'a> Binder<'a> {
         let (on_conflict, conflict_predicate) = match &insert.on {
             Some(on) => self.bind_conflict(on, &target, &columns),
             None => (Vec::new(), Vec::new()),
+        };
+        // An inline-view target's WHERE resolves against the target alone
+        // (filter reads — e.g. the predicate a `WITH CHECK OPTION` enforces).
+        // The base table may be aliased (`FROM emp e`); the predicate then
+        // qualifies through the alias (`e.dept`), so carry it on the scope.
+        let target_predicate = match view.and_then(|v| v.selection.as_ref()) {
+            Some(predicate) => {
+                let alias = view
+                    .and_then(|v| v.from.first())
+                    .and_then(|f| match &f.relation {
+                        TableFactor::Table { alias, .. } => alias.as_ref().map(|a| a.name.clone()),
+                        _ => None,
+                    });
+                let scope = self.target_scope_with_alias(&target, alias);
+                vec![self.bind_expr(predicate, &scope)]
+            }
+            None => Vec::new(),
         };
         // RETURNING resolves against the target alone (the source query's
         // scope is already popped).
@@ -232,6 +263,7 @@ impl<'a> Binder<'a> {
             returning,
             on_conflict,
             conflict_predicate,
+            target_predicate,
             source_wildcard,
         })
     }
@@ -304,7 +336,9 @@ impl<'a> Binder<'a> {
             returning,
             on_conflict,
             conflict_predicate,
-            // The MySQL SET form has no source query, so no wildcard.
+            // The MySQL SET form has no inline-view target and no source
+            // query, so no target predicate / wildcard.
+            target_predicate: Vec::new(),
             source_wildcard: false,
         })
     }
@@ -851,6 +885,18 @@ impl<'a> Binder<'a> {
     /// whose references resolve against the target alone — the source query's
     /// scope is already popped).
     pub(super) fn target_scope(&self, target: &TableReference) -> Scope {
+        self.target_scope_with_alias(target, None)
+    }
+
+    /// Like [`target_scope`](Self::target_scope), but exposing the target under
+    /// `alias` — an Oracle inline-view target's base table may be aliased
+    /// (`FROM emp e`), and its WHERE predicate qualifies through that alias
+    /// (`e.dept`), which then shadows the bare table name as usual.
+    pub(super) fn target_scope_with_alias(
+        &self,
+        target: &TableReference,
+        alias: Option<Ident>,
+    ) -> Scope {
         let m = self.table_match(target);
         let columns = if m.columns.is_empty() {
             Columns::Unknown
@@ -858,7 +904,7 @@ impl<'a> Binder<'a> {
             Columns::Cataloged(m.columns)
         };
         Scope::single(Relation::Table {
-            alias: None,
+            alias,
             table: m.table,
             columns,
         })
@@ -1233,6 +1279,31 @@ fn is_join_factor(factor: &TableFactor) -> bool {
         } => !table_with_joins.joins.is_empty() || is_join_factor(&table_with_joins.relation),
         _ => false,
     }
+}
+
+/// The insertable target columns an Oracle inline-view INSERT target's
+/// projection names: each item's underlying plain column (`a` / `t.a` /
+/// `a AS x` all name base column `a` — an alias renames the view column, the
+/// row still lands in the base one). Empty when *any* item is not a plain
+/// column (a wildcard / expression): the positional pairing is then
+/// indeterminate as a whole, so the caller falls back to the column-less
+/// (catalog-fill / diagnostic) path. The `SelectItem` match is exhaustive so a
+/// new variant forces a decision here.
+fn view_target_columns(select: &sqlparser::ast::Select) -> Vec<Ident> {
+    let mut columns = Vec::new();
+    for item in &select.projection {
+        let expr = match item {
+            SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => expr,
+            SelectItem::ExprWithAliases { .. }
+            | SelectItem::QualifiedWildcard(..)
+            | SelectItem::Wildcard(_) => return Vec::new(),
+        };
+        match inferred_name(expr) {
+            Some(column) => columns.push(column),
+            None => return Vec::new(),
+        }
+    }
+    columns
 }
 
 /// Whether a query's output projection contains an (unexpanded) wildcard

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -217,12 +217,17 @@ pub(crate) struct Values {
 pub(crate) struct Insert {
     pub(crate) target: TableWrite,
     /// Written target columns, each catalog-resolved against the target
-    /// (explicit list, or catalog-filled for a column-less INSERT).
+    /// (explicit list — from an `(a, b)` list or an Oracle inline-view target's
+    /// projection — or catalog-filled for a column-less INSERT).
     pub(crate) columns: Vec<ColumnWrite>,
     pub(crate) input: Box<LogicalPlan>,
     pub(crate) returning: Vec<NamedExpr>,
     pub(crate) on_conflict: Vec<Assignment>,
     pub(crate) conflict_predicate: Vec<Expr>,
+    /// An Oracle inline-view target's WHERE predicate
+    /// (`INSERT INTO (SELECT … FROM t WHERE …) …`): filter reads against the
+    /// target — its columns read, but never originate a value.
+    pub(crate) target_predicate: Vec<Expr>,
     pub(crate) source_wildcard: bool,
 }
 
@@ -590,6 +595,7 @@ pub(super) fn own_exprs(op: &LogicalPlan) -> Vec<&Expr> {
             .map(|ne| &ne.expr)
             .chain(i.on_conflict.iter().map(|a| &a.value))
             .chain(i.conflict_predicate.iter())
+            .chain(i.target_predicate.iter())
             .collect(),
         LogicalPlan::Update(u) => u
             .assignments

--- a/sql-insight/tests/column_operation_extractor/diagnostics.rs
+++ b/sql-insight/tests/column_operation_extractor/diagnostics.rs
@@ -52,14 +52,16 @@ mod reported {
     }
 
     #[test]
-    fn insert_into_subquery_target_reports_diagnostic() {
-        // Oracle `INSERT INTO (SELECT …) …`: the target is a subquery, not a
-        // writable base table — flagged (like the non-table UPDATE / MERGE
-        // target above), not dropped silently. The statement_kind stays Insert;
-        // nothing is written. (`OracleDialect` parses the subquery target.)
+    fn insert_into_join_view_target_reports_diagnostic() {
+        // Oracle `INSERT INTO (SELECT … JOIN …) …`: a join view names no single
+        // base table SQL text can determine (key-preserved rules need a
+        // catalog) — flagged (like the non-table UPDATE / MERGE target above),
+        // not dropped silently. The statement_kind stays Insert; nothing is
+        // written. (A *single-table* inline view resolves through to its base
+        // table instead — see `writes_deletes::insert_inline_view_target`.)
         assert_column_ops_with_dialect(
             &OracleDialect {},
-            "INSERT INTO (SELECT a FROM t) VALUES (1)",
+            "INSERT INTO (SELECT e.id FROM emp e JOIN dept d ON e.dept = d.id) VALUES (1)",
             ColumnOperation {
                 statement_kind: StatementKind::Insert,
                 reads: vec![],

--- a/sql-insight/tests/column_operation_extractor/writes_deletes.rs
+++ b/sql-insight/tests/column_operation_extractor/writes_deletes.rs
@@ -201,3 +201,183 @@ mod delete {
         );
     }
 }
+
+mod insert_inline_view_target {
+    //! Oracle `INSERT INTO (SELECT … FROM t [WHERE …]) …`: an inline-view
+    //! target resolves through to its single base table — the row lands there.
+    //! The view projection names the target columns, the WHERE is filter reads
+    //! against the target. A view over no single base table (a join) is
+    //! flagged instead — see
+    //! `diagnostics::reported::insert_into_join_view_target_reports_diagnostic`.
+    use super::*;
+    use sql_insight::sqlparser::dialect::OracleDialect;
+
+    #[test]
+    fn values_into_inline_view_writes_the_base_table_columns() {
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a, b FROM emp) VALUES (100, 'x')",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![write("emp", "a"), write("emp", "b")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn view_where_predicate_is_a_filter_read_on_the_target() {
+        // The WHERE restricts which rows the view exposes (what a
+        // `WITH CHECK OPTION` would enforce) — its columns read against the
+        // target, but never feed lineage (filter position).
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a FROM emp WHERE dept = 10) VALUES (100)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp", "dept")],
+                writes: vec![write("emp", "a")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn select_source_traces_through_the_view_to_the_base_column() {
+        // Relation lineage pairs the source outputs with the view's projected
+        // base columns positionally — `s.x → emp.a`.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a FROM emp) SELECT x FROM s",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s", "x")],
+                writes: vec![write("emp", "a")],
+                lineage: vec![passthrough(col("s", "x"), relation("emp", "a"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn aliased_view_column_writes_the_underlying_base_column() {
+        // `a AS x` renames the view column; the row still lands in base `a`.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a AS x FROM emp) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![write("emp", "a")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn wildcard_view_projection_is_column_less() {
+        // `SELECT *` names no target columns (wildcards aren't expanded) — the
+        // base table still surfaces as the write target, but its column writes
+        // drop with the usual column-less diagnostic (a catalog would fill
+        // them).
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT * FROM emp) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::InsertColumnsUnresolved)],
+            },
+        );
+    }
+
+    #[test]
+    fn expression_view_projection_is_column_less() {
+        // A non-column projection item (`a + 1`) makes the whole positional
+        // pairing indeterminate — same column-less path as the wildcard.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a + 1 FROM emp) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::InsertColumnsUnresolved)],
+            },
+        );
+    }
+
+    #[test]
+    fn view_columns_are_an_explicit_list_for_the_arity_check() {
+        // The view projection acts as the explicit column list: a wider VALUES
+        // row mismatches it exactly like `INSERT INTO emp (a) VALUES (1, 2)`.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a FROM emp) VALUES (1, 2)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![write("emp", "a")],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::InsertColumnsArityMismatch)],
+            },
+        );
+    }
+
+    #[test]
+    fn aliased_base_table_resolves_the_view_predicate() {
+        // The base table's alias (`FROM emp e`) is how the WHERE qualifies its
+        // refs (`e.dept`) — they resolve through the alias to `emp`, and (as
+        // usual) the alias shadows the bare table name.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.a FROM emp e WHERE e.dept = 10) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp", "dept")],
+                writes: vec![write("emp", "a")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn view_with_other_clauses_is_flagged_not_resolved() {
+        // Only the minimal insertable-view shape (projection + FROM + WHERE)
+        // resolves through. Any other clause — GROUP BY here, likewise
+        // DISTINCT / HAVING / ORDER BY / FETCH — makes the view
+        // non-insertable, and could carry column refs that would otherwise
+        // drop silently: flag + drop instead.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a FROM emp GROUP BY a) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+        // A *query*-level clause (ORDER BY, outside the SELECT) rejects too.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT a FROM emp ORDER BY b) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -415,6 +415,23 @@ mod insert_statement {
     }
 
     #[test]
+    fn test_insert_into_inline_view_writes_the_base_table() {
+        // Oracle `INSERT INTO (SELECT … FROM emp WHERE …) …`: the row lands in
+        // the view's single base table, so `emp` is the create target; the
+        // WHERE reads the target's own data, so `emp` also surfaces as a read.
+        use sql_insight::sqlparser::dialect::OracleDialect;
+        let sql = "INSERT INTO (SELECT a FROM emp WHERE dept = 10) VALUES (100)";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("emp"))],
+            read_tables: vec![cread(table("emp"))],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, vec![Box::new(OracleDialect {})]);
+    }
+
+    #[test]
     fn test_parenthesized_insert_keeps_the_insert_verb() {
         // `(INSERT … SELECT …)` keeps its verb → target buckets as Create,
         // source as Read (the misclassification dropped both into a Select).


### PR DESCRIPTION
## Summary

Implements a follow-up noted in #55: Oracle's inline-view INSERT
(`INSERT INTO (SELECT … FROM emp) …`) now resolves through to the view's single
base table as the write target, instead of dropping the whole statement as an
unsupported target. Semantically the row lands in the base table — the subquery
is an unnamed updatable view that restricts columns / enforces a predicate.

What resolves (single-table view only):

- **Write target** = the view's base table: `INSERT INTO (SELECT a FROM emp) …`
  writes `emp` (table level: `create_tables=[emp]`).
- **Target columns** = the view projection, as an explicit column list — plain
  columns only; `a AS x` writes base `a`. A wildcard / expression projection
  makes positions indeterminate → the usual column-less path (catalog fill, or
  `InsertColumnsUnresolved`). The explicit list also drives the arity check
  (`… (SELECT a FROM emp) VALUES (1, 2)` → `InsertColumnsArityMismatch`).
- **View WHERE** = filter reads against the target (what a `WITH CHECK OPTION`
  would enforce; sqlparser cannot parse the `WITH CHECK OPTION` keywords inside
  the target, so the plain predicate is what surfaces): reads `emp.dept`, never
  a lineage source. Carried on a new internal `Insert::target_predicate`.
- **Column lineage** traces through the view:
  `INSERT INTO (SELECT a FROM emp) SELECT x FROM s` → `s.x → emp.a`.

What stays flagged (`UnsupportedStatement`, as before): everything but the
minimal insertable-view shape (projection + FROM + WHERE). A join (Oracle's
key-preserved rules need a catalog), a set operation, a nested `WITH` / pipe
chain, or a non-table factor names no single base table — and any other clause
(GROUP BY / HAVING / DISTINCT / ORDER BY / FETCH / CONNECT BY / …) makes the
view non-insertable (ORA-01732) and could carry column refs that would
otherwise drop silently. Enforced by exhaustive `Query` / `Select`
destructures, so a new sqlparser clause forces a keep-or-reject decision.

Edge cases covered on review:

- An **aliased base table** (`INSERT INTO (SELECT e.a FROM emp e WHERE
  e.dept = 10) …`): the predicate's `e.dept` resolves through the alias to
  `emp.dept` (and, as in SQL, the alias shadows the bare table name).
- **Clause-bearing views** (`GROUP BY` / `ORDER BY` / `DISTINCT` / `FETCH`)
  previously slipped through the shape check with their column refs silently
  dropped — now rejected to the flag+drop path.
- `INSERT OVERWRITE` / `REPLACE INTO` bucketing (`peel_to_insert`) only reads
  the flags — unaffected.

`TableReference`'s `TryFrom<&Insert>` sees through the same shapes (and errors
on the rest), so the public target-identity parse agrees with the analysis.

Tests: 7 column-level cases (values / WHERE-reads / lineage-through-view /
alias / wildcard / expression / arity), a table-level CRUD case, a
`TryFrom<&Insert>` unit test, and the existing subquery-target diagnostic test
narrowed to a join view. All gates green (fmt / clippy / `test --all` / doc).

Only `OracleDialect` parses this syntax (`supports_insert_table_query`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
