### PR TITLE
feat: fan out multi-column-alias lineage to every alias

### DIFF
--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -56,10 +56,10 @@ use sqlparser::ast::{
 use sqlparser::tokenizer::Span;
 
 use super::logical_plan::{
-    Aggregate, AlterTable, Assignment, Binding, BoundColumn, Columns, CreateTableAs, CreateView,
-    Cte, CteRef, Delete, Drop, Expr, Filter, Insert, Join, LogicalPlan, Merge, MergeClause,
-    NamedExpr, Projection, Scan, SchemaSource, SetOp, Sort, SubqueryAlias, TableFunction, Update,
-    Values, With,
+    output_slots, slot_count, Aggregate, AlterTable, Assignment, Binding, BoundColumn, Columns,
+    CreateTableAs, CreateView, Cte, CteRef, Delete, Drop, Expr, Filter, Insert, Join, LogicalPlan,
+    Merge, MergeClause, NamedExpr, OutputNames, Projection, Scan, SchemaSource, SetOp, Sort,
+    SubqueryAlias, TableFunction, Update, Values, With,
 };
 use super::origins::output_operands;
 use crate::casing::{CaseRule, IdentifierStyle};
@@ -330,10 +330,8 @@ impl<'a> Binder<'a> {
         let Some(operand) = operands.first() else {
             return;
         };
-        let anonymous = operand
-            .outputs
-            .iter()
-            .filter(|ne| ne.name.is_none())
+        let anonymous = output_slots(operand.outputs)
+            .filter(|(name, _)| name.is_none())
             .count();
         if anonymous == 0 {
             return;
@@ -370,9 +368,9 @@ impl<'a> Binder<'a> {
             return;
         }
         if let Some(operand) = output_operands(input).first() {
-            let outputs = operand.outputs;
-            if !outputs.is_empty() && outputs.len() != explicit.len() {
-                self.record_created_columns_arity_mismatch(target, explicit.len(), outputs.len());
+            let outputs = slot_count(operand.outputs);
+            if outputs != 0 && outputs != explicit.len() {
+                self.record_created_columns_arity_mismatch(target, explicit.len(), outputs);
             }
         }
     }
@@ -679,8 +677,23 @@ fn rename_outputs(op: &mut LogicalPlan, names: &[Ident]) {
     }
     match op {
         LogicalPlan::Projection(p) => {
-            for (ne, n) in p.exprs.iter_mut().zip(names) {
-                ne.name = Some(n.clone());
+            let mut names = names.iter();
+            for ne in p.exprs.iter_mut() {
+                match &mut ne.names {
+                    OutputNames::Single(slot) => {
+                        if let Some(n) = names.next() {
+                            *slot = Some(n.clone());
+                        }
+                    }
+                    // A fan occupies one position per name — each renames.
+                    OutputNames::Fan(fan) => {
+                        for slot in fan.iter_mut() {
+                            if let Some(n) = names.next() {
+                                *slot = n.clone();
+                            }
+                        }
+                    }
+                }
             }
         }
         LogicalPlan::Sort(s) => rename_outputs(&mut s.input, names),

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -8,38 +8,24 @@ impl<'a> Binder<'a> {
     pub(super) fn bind_select_item(&mut self, item: &SelectItem, scope: &Scope) -> Vec<NamedExpr> {
         match item {
             SelectItem::UnnamedExpr(expr) => vec![NamedExpr {
-                name: inferred_name(expr),
+                names: OutputNames::Single(inferred_name(expr)),
                 expr: self.bind_expr(expr, scope),
             }],
             SelectItem::ExprWithAlias { expr, alias } => vec![NamedExpr {
-                name: Some(alias.clone()),
+                names: OutputNames::Single(Some(alias.clone())),
                 expr: self.bind_expr(expr, scope),
             }],
             // Spark `expr AS (a, b, …)`: one expression projected under several
-            // output names (e.g. `explode(arr) AS (key, value)`). Because
-            // `reads` is occurrence-based, the expression's columns must be
-            // counted exactly once — so only the first alias carries the bound
-            // expression (with its reads / lineage); the remaining aliases are
-            // extra output columns that trace to nothing, like a
-            // `(VALUES …) AS v(x)` derived column. Splitting one expression's
-            // lineage across N outputs isn't representable without re-reading
-            // it, so those tail outputs are best-effort.
-            SelectItem::ExprWithAliases { expr, aliases } => {
-                let bound = self.bind_expr(expr, scope);
-                let mut names = aliases.iter();
-                let head = NamedExpr {
-                    name: names.next().cloned(),
-                    expr: bound,
-                };
-                std::iter::once(head)
-                    .chain(names.map(|a| NamedExpr {
-                        name: Some(a.clone()),
-                        // An empty `Call` reads nothing and originates from
-                        // nothing (a `Derived` output).
-                        expr: Expr::Call { args: Vec::new() },
-                    }))
-                    .collect()
-            }
+            // output names (e.g. `explode(arr) AS (key, value)`) — one *fan*
+            // item occupying one output position per alias. The expression
+            // exists once, so `reads` count it once (occurrence-based); the
+            // slot view expands the names, so lineage fans out — every output
+            // column traces to the expression's sources (`arr → key` *and*
+            // `arr → value`).
+            SelectItem::ExprWithAliases { expr, aliases } => vec![NamedExpr {
+                names: OutputNames::Fan(aliases.clone()),
+                expr: self.bind_expr(expr, scope),
+            }],
             // A wildcard isn't expanded (the rigor cost is too high for a
             // SQL-text-only library); record it so consumers know this
             // projection's column lineage is incomplete. A `REPLACE (expr AS
@@ -67,7 +53,7 @@ impl<'a> Binder<'a> {
                 // explicit outputs follow.
                 let mut out = match kind {
                     SelectItemQualifiedWildcardKind::Expr(expr) => vec![NamedExpr {
-                        name: None,
+                        names: OutputNames::Single(None),
                         expr: Expr::Call {
                             args: vec![self.bind_expr(expr, scope)],
                         },
@@ -94,7 +80,7 @@ impl<'a> Binder<'a> {
             .iter()
             .flat_map(|replace| &replace.items)
             .map(|element| NamedExpr {
-                name: Some(element.column_name.clone()),
+                names: OutputNames::Single(Some(element.column_name.clone())),
                 expr: self.bind_expr(&element.expr, scope),
             })
             .collect()
@@ -767,28 +753,27 @@ impl<'a> Binder<'a> {
     pub(super) fn output_cols(&self, exprs: &[NamedExpr]) -> Vec<OutputCol> {
         exprs
             .iter()
-            .map(|ne| {
+            .flat_map(|ne| {
                 // An identity output re-reads a real base column (so a later
                 // clause-alias / pipe reference to it reads that column). Only a
                 // `Base` column qualifies: a `Derived` passthrough (a pipe-
                 // carried alias, a derived-table column) traces back through the
                 // projection chain, not to a base table — marking it identity
                 // would let a later stage fall through to the base relation and
-                // fabricate a phantom read.
-                let identity = match &ne.expr {
-                    Expr::Column(c) => {
+                // fabricate a phantom read. A fan's names are always introduced
+                // aliases (never the column itself), so never identity.
+                let identity = match (&ne.names, &ne.expr) {
+                    (OutputNames::Single(Some(name)), Expr::Column(c)) => {
                         matches!(c.binding, Binding::Base { .. })
-                            && ne
-                                .name
-                                .as_ref()
-                                .is_some_and(|n| self.eq(self.style.casing.column, n, &c.name))
+                            && self.eq(self.style.casing.column, name, &c.name)
                     }
                     _ => false,
                 };
-                OutputCol {
-                    name: ne.name.clone(),
+                // One `OutputCol` per output position (a fan expands).
+                (0..ne.names.count()).map(move |j| OutputCol {
+                    name: ne.names.get(j).flatten().cloned(),
                     identity,
-                }
+                })
             })
             .collect()
     }

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -184,7 +184,9 @@ impl<'a> Binder<'a> {
                     .iter()
                     .chain(group_by_expr)
                     .map(|e| NamedExpr {
-                        name: e.expr.alias.clone().or_else(|| inferred_name(&e.expr.expr)),
+                        names: OutputNames::Single(
+                            e.expr.alias.clone().or_else(|| inferred_name(&e.expr.expr)),
+                        ),
                         expr: self.bind_expr(&e.expr.expr, scope),
                     })
                     .collect();
@@ -311,7 +313,7 @@ impl<'a> Binder<'a> {
                 expr: Expr::Column(Box::new(
                     self.resolve(std::slice::from_ref(&name), &pass_scope),
                 )),
-                name: Some(name),
+                names: OutputNames::Single(Some(name)),
             })
             .collect()
     }
@@ -329,13 +331,13 @@ impl<'a> Binder<'a> {
         for a in assignments {
             for column in assignment_target_columns(&a.target) {
                 let ne = NamedExpr {
-                    name: Some(column.clone()),
+                    names: OutputNames::Single(Some(column.clone())),
                     expr: self.bind_expr(&a.value, scope),
                 };
+                // Pipe outputs are always single-named passthroughs.
                 match exprs.iter_mut().find(|e| {
-                    e.name
-                        .as_ref()
-                        .is_some_and(|n| self.eq(self.style.casing.column, n, &column))
+                    matches!(&e.names, OutputNames::Single(Some(n))
+                        if self.eq(self.style.casing.column, n, &column))
                 }) {
                     Some(slot) => *slot = ne,
                     None => exprs.push(ne),

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -207,7 +207,7 @@ impl<'a> Binder<'a> {
                 LogicalPlan::Values(v) => v.rows.first().map(Vec::len),
                 other => output_operands(other)
                     .first()
-                    .map(|operand| operand.outputs.len())
+                    .map(|operand| slot_count(operand.outputs))
                     .filter(|n| *n > 0),
             }
         };
@@ -311,7 +311,7 @@ impl<'a> Binder<'a> {
         for assignment in &insert.assignments {
             for column in assignment_target_columns(&assignment.target) {
                 exprs.push(NamedExpr {
-                    name: Some(column.clone()),
+                    names: OutputNames::Single(Some(column.clone())),
                     expr: self.bind_expr(&assignment.value, &scope),
                 });
                 columns.push(column);

--- a/sql-insight/src/resolver/lineage.rs
+++ b/sql-insight/src/resolver/lineage.rs
@@ -12,7 +12,8 @@
 use sqlparser::ast::Ident;
 
 use super::logical_plan::{
-    dml_roots, is_dml_root, peel_with, Expr, LogicalPlan, MergeClause, NamedExpr, Update,
+    dml_roots, is_dml_root, output_slots, peel_with, Expr, LogicalPlan, MergeClause, NamedExpr,
+    Update,
 };
 use super::origins::{
     conflict_value_origins, enter_withs, origins_of_expr, output_operands, TraceContext,
@@ -197,18 +198,21 @@ fn query_output_lineage<'a>(
     // column). Position already restarts per branch, aligning them; a plain
     // query has a single operand, so this is a no-op there.
     let result_names: Vec<Option<Ident>> = match operands.first() {
-        Some(o) => o.outputs.iter().map(|ne| ne.name.clone()).collect(),
+        Some(o) => output_slots(o.outputs).map(|(n, _)| n.cloned()).collect(),
         None => Vec::new(),
     };
     for operand in &operands {
         let outputs = operand.outputs;
         operand.trace(context, |input, cx| {
-            for (position, ne) in outputs.iter().enumerate() {
+            // Position-by-position over the slot view: a fan yields its
+            // shared expression once per alias, so every alias of
+            // `explode(arr) AS (k, v)` gets its own `arr` edge.
+            for (position, (_, expr)) in output_slots(outputs).enumerate() {
                 let target = ColumnTarget::QueryOutput {
                     name: result_names.get(position).cloned().flatten(),
                     position,
                 };
-                emit_edges(origins_of_expr(&ne.expr, input, cx), target, out);
+                emit_edges(origins_of_expr(expr, input, cx), target, out);
             }
         });
     }
@@ -263,9 +267,12 @@ fn relation_lineage<'a>(
     for operand in output_operands(input) {
         let outputs = operand.outputs;
         operand.trace(context, |src_input, cx| {
-            for (target_column, ne) in columns.iter().zip(outputs) {
+            // Pair positionally with the slot view: a fan feeds one target
+            // column per alias (`INSERT … SELECT explode(arr) AS (k, v)`
+            // feeds both).
+            for (target_column, (_, expr)) in columns.iter().zip(output_slots(outputs)) {
                 let tgt = ColumnTarget::Relation(target_column.clone());
-                emit_edges(origins_of_expr(&ne.expr, src_input, cx), tgt, out);
+                emit_edges(origins_of_expr(expr, src_input, cx), tgt, out);
             }
         });
     }
@@ -300,7 +307,7 @@ fn created_relation_lineage<'a>(
     let operands = output_operands(input);
     let result_names: Vec<Option<Ident>> = if explicit.is_empty() {
         match operands.first() {
-            Some(o) => o.outputs.iter().map(|ne| ne.name.clone()).collect(),
+            Some(o) => output_slots(o.outputs).map(|(n, _)| n.cloned()).collect(),
             None => Vec::new(),
         }
     } else {
@@ -309,7 +316,9 @@ fn created_relation_lineage<'a>(
     for operand in &operands {
         let outputs = operand.outputs;
         operand.trace(context, |src_input, cx| {
-            for (position, ne) in outputs.iter().enumerate() {
+            // Position-by-position over the slot view, so a CTAS / CREATE
+            // VIEW over `explode(arr) AS (k, v)` feeds both created columns.
+            for (position, (_, expr)) in output_slots(outputs).enumerate() {
                 let Some(name) = result_names.get(position).cloned().flatten() else {
                     continue;
                 };
@@ -321,7 +330,7 @@ fn created_relation_lineage<'a>(
                     },
                     resolution: ResolutionKind::Inferred,
                 });
-                emit_edges(origins_of_expr(&ne.expr, src_input, cx), tgt, out);
+                emit_edges(origins_of_expr(expr, src_input, cx), tgt, out);
             }
         });
     }
@@ -336,12 +345,12 @@ fn returning_lineage<'a>(
     context: &mut TraceContext<'a>,
     out: &mut Vec<ColumnLineageEdge>,
 ) {
-    for (position, ne) in returning.iter().enumerate() {
+    for (position, (name, expr)) in output_slots(returning).enumerate() {
         let target = ColumnTarget::QueryOutput {
-            name: ne.name.clone(),
+            name: name.cloned(),
             position,
         };
-        emit_edges(origins_of_expr(&ne.expr, input, context), target, out);
+        emit_edges(origins_of_expr(expr, input, context), target, out);
     }
 }
 

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -501,13 +501,80 @@ impl Expr {
     }
 }
 
-/// A named output expression — a projection item, an aggregate, a group key,
-/// or a `RETURNING` item. `name` is the explicit alias, else the inferred
-/// name (a bare column's own name), else `None` (anonymous).
+/// A named output item — a projection item, an aggregate, or a `RETURNING`
+/// item: one expression under one or several output names. The expression is
+/// always a real [`Expr`] and always exists exactly once, so `reads` count it
+/// once by construction; a multi-name item (a *fan*) occupies several adjacent
+/// output **positions**, so a list's item index is **not** its output position
+/// — positional and named access go through the slot view ([`output_slots`] /
+/// [`slot_count`] / [`resolved_output_expr`]).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct NamedExpr {
-    pub(crate) name: Option<Ident>,
+    pub(crate) names: OutputNames,
     pub(crate) expr: Expr,
+}
+
+/// The output name(s) of one [`NamedExpr`] item.
+///
+/// `Fan` is Spark's multi-column alias `expr AS (a, b, …)`: one expression
+/// producing several output columns (the one-source-many-outputs dual of
+/// [`Expr::Fanin`]). Keeping the fan **inside one item** — instead of
+/// splitting it into per-name entries linked by references — makes the
+/// sharing structural: the names and the expression can never separate (no
+/// dangling reference under any reorder / filter), lineage fans out by
+/// expanding the names, and the expression is walked once wherever items are
+/// walked.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum OutputNames {
+    /// An ordinary item: the explicit alias, else the inferred name (a bare
+    /// column's own name), else `None` (anonymous).
+    Single(Option<Ident>),
+    /// A multi-column alias — always explicit identifiers, one output
+    /// position per name.
+    Fan(Vec<Ident>),
+}
+
+impl OutputNames {
+    /// How many output positions this item occupies.
+    pub(crate) fn count(&self) -> usize {
+        match self {
+            OutputNames::Single(_) => 1,
+            OutputNames::Fan(names) => names.len(),
+        }
+    }
+
+    /// The name at the item's `j`-th position (inner `None` = anonymous;
+    /// outer `None` = out of range).
+    pub(crate) fn get(&self, j: usize) -> Option<Option<&Ident>> {
+        match self {
+            OutputNames::Single(name) => (j == 0).then_some(name.as_ref()),
+            OutputNames::Fan(names) => names.get(j).map(Some),
+        }
+    }
+}
+
+/// The number of output **positions** an output list produces — the item
+/// count plus fan expansion (`SELECT id, explode(a) AS (k, v)` = 2 items,
+/// 3 positions).
+pub(super) fn slot_count(outputs: &[NamedExpr]) -> usize {
+    outputs.iter().map(|ne| ne.names.count()).sum()
+}
+
+/// Iterate an output list position by position as `(name, expr)` pairs — a
+/// fan yields its shared expression once per name. The single positional /
+/// named access path over outputs (query-output lineage, DML relation
+/// pairing, RETURNING, CTAS / CREATE VIEW, set-operation / subquery /
+/// EXCLUDED traces, derived-table name traces), so every position of a fan
+/// traces exactly like its siblings.
+pub(super) fn output_slots(outputs: &[NamedExpr]) -> impl Iterator<Item = (Option<&Ident>, &Expr)> {
+    outputs
+        .iter()
+        .flat_map(|ne| (0..ne.names.count()).map(|j| (ne.names.get(j).flatten(), &ne.expr)))
+}
+
+/// The value expression at output **position** `i` (`None` = out of range).
+pub(super) fn resolved_output_expr(outputs: &[NamedExpr], i: usize) -> Option<&Expr> {
+    output_slots(outputs).nth(i).map(|(_, e)| e)
 }
 
 /// A `col = expr` assignment (UPDATE SET, MySQL INSERT … SET, ON CONFLICT

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -9,7 +9,9 @@
 
 use sqlparser::ast::Ident;
 
-use super::logical_plan::{Binding, BoundColumn, Cte, Expr, LogicalPlan, NamedExpr};
+use super::logical_plan::{
+    output_slots, resolved_output_expr, Binding, BoundColumn, Cte, Expr, LogicalPlan, NamedExpr,
+};
 use super::reads::column_read;
 use crate::casing::{CaseRule, IdentifierCasing};
 use crate::extractor::ColumnLineageKind;
@@ -225,10 +227,17 @@ fn origins_into<'a>(
     context: &mut TraceContext<'a>,
 ) -> Vec<(ColumnRead, ColumnLineageKind)> {
     match op {
-        LogicalPlan::Projection(p) => match find_named(&p.exprs, name, context.casing.column) {
-            Some(ne) => origins_of_expr(&ne.expr, &p.input, context),
-            None => Vec::new(),
-        },
+        LogicalPlan::Projection(p) => {
+            // Resolve by name to a position, then through any multi-alias
+            // back-reference — `d.v` over `explode(arr) AS (k, v)` traces the
+            // head expression, reaching `arr`.
+            match named_position(&p.exprs, name, context.casing.column)
+                .and_then(|i| resolved_output_expr(&p.exprs, i))
+            {
+                Some(expr) => origins_of_expr(expr, &p.input, context),
+                None => Vec::new(),
+            }
+        }
         // The projection resolves against the FROM scope, so a column is a
         // base ref that returns directly, not a named `Aggregate` output —
         // a `Derived` ref tracing down just passes through to the input.
@@ -279,9 +288,8 @@ fn origins_into<'a>(
         LogicalPlan::SetOp(_) => {
             let operands = output_operands(op);
             let Some(i) = operands.first().and_then(|o| {
-                o.outputs
-                    .iter()
-                    .position(|ne| ne.name.as_ref().is_some_and(|n| context.eq_column(n, name)))
+                output_slots(o.outputs)
+                    .position(|(n, _)| n.is_some_and(|n| context.eq_column(n, name)))
             }) else {
                 return Vec::new();
             };
@@ -369,8 +377,10 @@ fn trace_nth_output<'a>(
 ) -> Vec<(ColumnRead, ColumnLineageKind)> {
     let mut out = Vec::new();
     for operand in operands {
-        if let Some(ne) = operand.outputs.get(i) {
-            out.extend(operand.trace(context, |input, cx| origins_of_expr(&ne.expr, input, cx)));
+        // A multi-alias tail output resolves to its head expression, so a
+        // positional trace of `v` in `explode(arr) AS (k, v)` reaches `arr`.
+        if let Some(expr) = resolved_output_expr(operand.outputs, i) {
+            out.extend(operand.trace(context, |input, cx| origins_of_expr(expr, input, cx)));
         }
     }
     out
@@ -584,11 +594,9 @@ fn transform(
         .collect()
 }
 
-fn find_named<'a>(exprs: &'a [NamedExpr], name: &Ident, fold: CaseRule) -> Option<&'a NamedExpr> {
+/// The output **position** named `name` (case-folded), over the slot view —
+/// so a fan's aliases each occupy their own position.
+fn named_position(exprs: &[NamedExpr], name: &Ident, fold: CaseRule) -> Option<usize> {
     let target = fold.normalize(name);
-    exprs.iter().find(|ne| {
-        ne.name
-            .as_ref()
-            .is_some_and(|n| fold.normalize(n) == target)
-    })
+    output_slots(exprs).position(|(n, _)| n.is_some_and(|n| fold.normalize(n) == target))
 }

--- a/sql-insight/src/resolver/tables.rs
+++ b/sql-insight/src/resolver/tables.rs
@@ -9,7 +9,7 @@
 
 use sqlparser::ast::Ident;
 
-use super::logical_plan::{dml_roots, LogicalPlan, MergeClause};
+use super::logical_plan::{dml_roots, output_slots, LogicalPlan, MergeClause};
 use super::origins::output_operands;
 use crate::reference::{ColumnReference, ColumnWrite, ResolutionKind, TableReference, TableWrite};
 
@@ -183,10 +183,8 @@ fn created_relation_writes(
         return inferred_writes(explicit, target);
     }
     let names: Vec<Ident> = match output_operands(input).first() {
-        Some(operand) => operand
-            .outputs
-            .iter()
-            .filter_map(|ne| ne.name.clone())
+        Some(operand) => output_slots(operand.outputs)
+            .filter_map(|(n, _)| n.cloned())
             .collect(),
         None => Vec::new(),
     };

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -324,6 +324,45 @@ mod ctas_view {
     use super::*;
 
     #[test]
+    fn ctas_multi_column_alias_feeds_every_created_column() {
+        // A multi-alias projection (`explode(arr) AS (k, v)`) fans out: each
+        // created column pairs with its like-positioned output, and a tail
+        // alias resolves to the head expression — both `x.k` and `x.v`
+        // receive `t.arr` (the tail edge used to be silently missing).
+        assert_column_ops(
+            "CREATE TABLE x AS SELECT explode(arr) AS (k, v) FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::CreateTable,
+                reads: vec![read("t", "arr")],
+                writes: vec![write("x", "k"), write("x", "v")],
+                lineage: vec![
+                    transformation(col("t", "arr"), relation("x", "k")),
+                    transformation(col("t", "arr"), relation("x", "v")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn create_view_multi_column_alias_feeds_every_view_column() {
+        // Same fan-out through CREATE VIEW (the other created-relation path).
+        assert_column_ops(
+            "CREATE VIEW w AS SELECT explode(arr) AS (k, v) FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::CreateView,
+                reads: vec![read("t", "arr")],
+                writes: vec![write("w", "k"), write("w", "v")],
+                lineage: vec![
+                    transformation(col("t", "arr"), relation("w", "k")),
+                    transformation(col("t", "arr"), relation("w", "v")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn ctas_pairs_source_projection_with_inferred_column_names() {
         // CREATE TABLE AS SELECT — no explicit column list, so target
         // columns follow the source projection's inferred names

--- a/sql-insight/tests/column_operation_extractor/lineage.rs
+++ b/sql-insight/tests/column_operation_extractor/lineage.rs
@@ -53,18 +53,108 @@ mod projections {
     fn expr_with_multi_column_aliases_binds_the_expression_once() {
         // Spark `expr AS (a, b, …)`: one expression projected under several
         // output names. `reads` is occurrence-based, so `t.arr` is read exactly
-        // once; the expression's lineage attaches to the first alias (`k`), and
-        // the tail alias (`v`) is an extra output that traces to nothing —
-        // splitting one expression's lineage across N outputs isn't
-        // representable without re-reading it. (`GenericDialect` parses the
-        // multi-column alias.)
+        // once (the first alias carries the bound expression; each tail alias
+        // is a `Fanout` back-reference to it) — while lineage fans out: every
+        // alias gets its own edge from the expression's sources.
+        // (`GenericDialect` parses the multi-column alias.)
         assert_column_ops(
             "SELECT explode(t.arr) AS (k, v) FROM t",
             ColumnOperation {
                 statement_kind: StatementKind::Select,
                 reads: vec![read("t", "arr")],
                 writes: vec![],
-                lineage: vec![transformation(col("t", "arr"), out("k", 0))],
+                lineage: vec![
+                    transformation(col("t", "arr"), out("k", 0)),
+                    transformation(col("t", "arr"), out("v", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn multi_column_alias_of_a_bare_column_fans_out_passthroughs() {
+        // The fan-out edges take the *head expression's* kind: a bare column
+        // under several aliases is a `Passthrough` to each (a function like
+        // `explode` is a `Transformation` to each — previous test).
+        assert_column_ops(
+            "SELECT t.a AS (x, y) FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("x", 0)),
+                    passthrough(col("t", "a"), out("y", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn multi_column_alias_tail_traces_through_a_derived_table() {
+        // Selecting the *tail* alias through a derived table resolves its
+        // `Fanout` back to the head expression — `d.v` reaches `t.arr`.
+        assert_column_ops(
+            "SELECT v FROM (SELECT explode(arr) AS (k, v) FROM t) d",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "arr")],
+                writes: vec![],
+                lineage: vec![transformation(col("t", "arr"), out("v", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn derived_alias_list_renames_fan_names_positionally() {
+        // An explicit derived-table column list (`AS d(x, y)`) renames output
+        // *positions*: a fan consumes one name per alias (k→x, v→y), so the
+        // renamed tail (`y`) still traces to the fan's shared expression.
+        assert_column_ops(
+            "SELECT y FROM (SELECT explode(arr) AS (k, v) FROM t) AS d(x, y)",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "arr")],
+                writes: vec![],
+                lineage: vec![transformation(col("t", "arr"), out("y", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn cte_column_list_renames_fan_names_positionally() {
+        // The same positional rename through a CTE's explicit column list.
+        assert_column_ops(
+            "WITH c (x, y) AS (SELECT explode(arr) AS (k, v) FROM t) SELECT y FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "arr")],
+                writes: vec![],
+                lineage: vec![transformation(col("t", "arr"), out("y", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn multi_column_alias_feeds_every_insert_target_column() {
+        // INSERT pairing is positional: each target column pairs with its
+        // like-positioned output, and a tail alias resolves to the head
+        // expression — both `tgt.c1` and `tgt.c2` receive `t.arr`.
+        assert_column_ops(
+            "INSERT INTO tgt (c1, c2) SELECT explode(arr) AS (k, v) FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("t", "arr")],
+                writes: vec![write("tgt", "c1"), write("tgt", "c2")],
+                lineage: vec![
+                    transformation(col("t", "arr"), relation("tgt", "c1")),
+                    transformation(col("t", "arr"), relation("tgt", "c2")),
+                ],
                 diagnostics: vec![],
             },
         );


### PR DESCRIPTION
## Summary

Implements the last follow-up noted in #55 (design agreed in discussion):
lineage for Spark's multi-column alias `expr AS (a, b, …)` now **fans out to
every alias** instead of stopping at the first.

```sql
SELECT explode(t.arr) AS (k, v) FROM t
-- before: reads [t.arr],  lineage [arr → k]
-- after:  reads [t.arr],  lineage [arr → k, arr → v]
```

## Design: the fan is one item (no references)

`NamedExpr` gains `names: OutputNames` — `Single(Option<Ident>)` for an
ordinary item, `Fan(Vec<Ident>)` for a multi-column alias:

```text
SELECT id, explode(t.arr) AS (k, v), name FROM t
Projection.exprs = [                                  ← 3 items, 4 positions
  NamedExpr { names: Single(id),  expr: Column(t.id) }        // position 0
  NamedExpr { names: Fan([k, v]), expr: Call(explode(arr)) }  // positions 1, 2
  NamedExpr { names: Single(name), expr: Column(t.name) }     // position 3
]
```

- **The expression exists exactly once** → `reads` count it once by
  construction (occurrence-based, unchanged), and item walks (`own_exprs`)
  stay a plain map.
- **Names can never separate from their expression** — there is no
  back-reference to dangle under any reorder / filter / splice (the design
  review rejected a positional `Fanout { back }` reference and a
  `debug_assert`-guarded fallback for exactly this reason).
- **Item index ≠ output position**: every positional / named consumer goes
  through one slot view (`output_slots` / `slot_count` /
  `resolved_output_expr`), where a fan yields its shared expression once per
  name — query-output lineage, INSERT positional pairing, RETURNING, CTAS /
  CREATE VIEW, the shared positional trace (set-op branches, scalar
  subqueries, `EXCLUDED`), derived-table name traces, output-column scopes
  (`OutputCol`, fan outputs are never identity), `AS d(x, y)` positional
  renames, and the created-columns / insert arity checks.
- Edge kind = the head expression's kind: `explode(arr)` fans out
  `Transformation`s; a bare column `t.a AS (x, y)` fans out `Passthrough`s.

Non-breaking: output shapes are unchanged; lineage gains edges (the
first-alias-only behavior was a documented best-effort in #55, not a
contract).

Verified end-to-end: fan-out for 2 aliases, `Passthrough` fan-out for a bare
column, the tail alias traced through a derived table, INSERT pairing and
CTAS / CREATE VIEW feeding every target column, positional fan renames through
a derived alias list (`AS d(x, y)`) and a CTE column list, UNION branches
tracing positionally (existing reads-once pins unchanged). All gates green
(fmt / clippy / `test --all` / doc); 766 tests, **100% patch coverage**
(llvm-cov ∩ diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
