### PR TITLE
feat: resolve Oracle join-view INSERT targets by column attribution

### DIFF
--- a/sql-insight/src/reference.rs
+++ b/sql-insight/src/reference.rs
@@ -10,8 +10,8 @@ use core::fmt;
 use crate::casing::IdentifierCasing;
 use crate::error::Error;
 use sqlparser::ast::{
-    GroupByExpr, Ident, Insert, JoinOperator, ObjectName, Query, Select, SelectFlavor, SetExpr,
-    TableFactor, TableObject,
+    Expr, GroupByExpr, Ident, Insert, JoinOperator, ObjectName, Query, Select, SelectFlavor,
+    SelectItem, SetExpr, TableFactor, TableObject,
 };
 
 /// Physical table identity — the `catalog.schema.name` triplet.
@@ -584,15 +584,23 @@ impl TryFrom<&ObjectName> for TableReference {
     }
 }
 
-/// A shape-gated Oracle inline-view INSERT target: the view\'s [`Select`]
-/// plus its FROM factors **pre-extracted** as `(name, alias)` pairs — the
-/// gate proves every factor is a plain table, and handing the proof over as
-/// data means no downstream re-match (and no unreachable fallback arm).
+/// A shape-gated Oracle inline-view INSERT target, handed over entirely as
+/// **gate-extracted data** — the FROM factors as `(name, alias)` pairs, the
+/// projection, the join operators, and the WHERE. The gate proves every
+/// factor is a plain table; carrying the proof as data means no downstream
+/// re-match (no unreachable fallback arm), and nothing re-reads the `Query`,
+/// so no consumer can pair `factors` with a clause it wasn\'t derived from.
 pub(crate) struct InsertTargetView<'a> {
-    pub(crate) select: &'a Select,
-    /// Every FROM factor (each `TableWithJoins`\' relation and joins, in
+    /// Every FROM factor (each `TableWithJoins`' relation and joins, in
     /// source order): its table name and optional alias.
     pub(crate) factors: Vec<(&'a ObjectName, Option<&'a Ident>)>,
+    /// The projection items — the insertable target columns' material.
+    pub(crate) projection: &'a [SelectItem],
+    /// Every join's operator, the constraint carrier (no relation data — that
+    /// lives in `factors`): the binder binds each `ON` as filter reads.
+    pub(crate) join_operators: Vec<&'a JoinOperator>,
+    /// The WHERE predicate — filter reads over the view's relations.
+    pub(crate) selection: Option<&'a Expr>,
 }
 
 /// Shape-gate an Oracle inline-view INSERT target
@@ -635,13 +643,13 @@ pub(crate) fn insert_target_view(query: &Query) -> Option<InsertTargetView<'_>> 
         select_modifiers: None,
         top: None,
         top_before_distinct: _,
-        projection: _,
+        projection,
         exclude: None,
         into: None,
         from,
         lateral_views,
         prewhere: None,
-        selection: _,
+        selection,
         connect_by,
         group_by: GroupByExpr::Expressions(group_by, group_by_modifiers),
         cluster_by,
@@ -683,6 +691,7 @@ pub(crate) fn insert_target_view(query: &Query) -> Option<InsertTargetView<'_>> 
         }
     }
     let mut factors = Vec::new();
+    let mut join_operators = Vec::new();
     for twj in from {
         factors.push(plain_table(&twj.relation)?);
         for join in &twj.joins {
@@ -697,9 +706,15 @@ pub(crate) fn insert_target_view(query: &Query) -> Option<InsertTargetView<'_>> 
                 return None;
             }
             factors.push(plain_table(&join.relation)?);
+            join_operators.push(&join.join_operator);
         }
     }
-    Some(InsertTargetView { select, factors })
+    Some(InsertTargetView {
+        factors,
+        projection,
+        join_operators,
+        selection: selection.as_ref(),
+    })
 }
 
 /// The single base table of a shape-gated inline view
@@ -834,7 +849,14 @@ mod tests {
             query
         };
         let plain = parse("SELECT e.id FROM emp e JOIN dept d ON e.id = d.id");
-        assert!(insert_target_view(&plain).is_some());
+        let view = insert_target_view(&plain).unwrap();
+        // The gate hands everything over as extracted data: both factors
+        // (with aliases), the join's operator, and the projection.
+        assert_eq!(view.factors.len(), 2);
+        assert_eq!(view.factors[1].1.unwrap().value, "d");
+        assert_eq!(view.join_operators.len(), 1);
+        assert_eq!(view.projection.len(), 1);
+        assert!(view.selection.is_none());
         let array_join = parse("SELECT e.id FROM emp e ARRAY JOIN arr");
         assert!(insert_target_view(&array_join).is_none());
     }

--- a/sql-insight/src/reference.rs
+++ b/sql-insight/src/reference.rs
@@ -10,8 +10,8 @@ use core::fmt;
 use crate::casing::IdentifierCasing;
 use crate::error::Error;
 use sqlparser::ast::{
-    GroupByExpr, Ident, Insert, ObjectName, Query, Select, SelectFlavor, SetExpr, TableFactor,
-    TableObject,
+    GroupByExpr, Ident, Insert, JoinOperator, ObjectName, Query, Select, SelectFlavor, SetExpr,
+    TableFactor, TableObject,
 };
 
 /// Physical table identity — the `catalog.schema.name` triplet.
@@ -344,14 +344,22 @@ impl TableReference {
         let name = match &value.table {
             TableObject::TableName(object_name) => object_name,
             TableObject::TableFunction(function) => &function.name,
-            TableObject::TableQuery(query) => match insert_target_view(query) {
-                Some((name, _)) => name,
-                None => {
-                    return Err(Error::AnalysisError(
-                        "INSERT target is a subquery over no single base table".to_string(),
-                    ))
+            // Only a single-table view is shape-determined; a join view's base
+            // table needs binder resolution (column attribution), out of reach
+            // of a plain identity parse.
+            TableObject::TableQuery(query) => {
+                match insert_target_view(query)
+                    .as_ref()
+                    .and_then(insert_target_base)
+                {
+                    Some(name) => name,
+                    None => {
+                        return Err(Error::AnalysisError(
+                            "INSERT target is a subquery over no single base table".to_string(),
+                        ))
+                    }
                 }
-            },
+            }
         };
         // `Insert::table_alias` is now a `TableAliasWithoutColumns`; the public
         // pair still exposes just the alias identifier.
@@ -576,19 +584,29 @@ impl TryFrom<&ObjectName> for TableReference {
     }
 }
 
-/// See through an Oracle inline-view INSERT target
-/// (`INSERT INTO (SELECT … FROM t [WHERE …]) …`) to its single base table:
-/// the `SELECT`'s one plain-table FROM item. Only the minimal insertable-view
-/// shape passes — a projection, the single FROM table, and an optional WHERE.
-/// `None` for everything else: a join / set operation / non-table factor
-/// names no single base table SQL text can determine (Oracle's key-preserved
-/// rules need a catalog), and any other clause (GROUP BY / HAVING / DISTINCT /
-/// ORDER BY / FETCH / CONNECT BY / …) makes the view non-insertable — and
-/// could carry column references that would otherwise drop silently. The
-/// returned [`Select`] carries the projection (the insertable target columns)
-/// and the WHERE predicate for the caller. Both destructures are exhaustive,
-/// so a new `Query` / `Select` clause forces a keep-or-reject decision here.
-pub(crate) fn insert_target_view(query: &Query) -> Option<(&ObjectName, &Select)> {
+/// A shape-gated Oracle inline-view INSERT target: the view\'s [`Select`]
+/// plus its FROM factors **pre-extracted** as `(name, alias)` pairs — the
+/// gate proves every factor is a plain table, and handing the proof over as
+/// data means no downstream re-match (and no unreachable fallback arm).
+pub(crate) struct InsertTargetView<'a> {
+    pub(crate) select: &'a Select,
+    /// Every FROM factor (each `TableWithJoins`\' relation and joins, in
+    /// source order): its table name and optional alias.
+    pub(crate) factors: Vec<(&'a ObjectName, Option<&'a Ident>)>,
+}
+
+/// Shape-gate an Oracle inline-view INSERT target
+/// (`INSERT INTO (SELECT … FROM …) …`): only the minimal insertable-view shape
+/// passes — a projection, a FROM of **plain tables** (a single table, or a
+/// join / comma list of them; `ARRAY JOIN` operands are not tables), and an
+/// optional WHERE. `None` for everything else: a non-table factor, or any
+/// other clause (GROUP BY / HAVING / DISTINCT / ORDER BY / FETCH / CONNECT BY
+/// / …) makes the view non-insertable — and could carry column references
+/// that would otherwise drop silently. Which table the row lands in is
+/// [`insert_target_base`] for the single-table shape, and binder-side column
+/// attribution for a join view. Both destructures are exhaustive, so a new
+/// `Query` / `Select` clause forces a keep-or-reject decision here.
+pub(crate) fn insert_target_view(query: &Query) -> Option<InsertTargetView<'_>> {
     let Query {
         with: None,
         body,
@@ -650,16 +668,49 @@ pub(crate) fn insert_target_view(query: &Query) -> Option<(&ObjectName, &Select)
     {
         return None;
     }
-    let [from] = from.as_slice() else {
-        return None;
-    };
-    if !from.joins.is_empty() {
+    if from.is_empty() {
         return None;
     }
-    match &from.relation {
-        TableFactor::Table {
-            name, args: None, ..
-        } => Some((name, select)),
+    fn plain_table(factor: &TableFactor) -> Option<(&ObjectName, Option<&Ident>)> {
+        match factor {
+            TableFactor::Table {
+                name,
+                alias,
+                args: None,
+                ..
+            } => Some((name, alias.as_ref().map(|a| &a.name))),
+            _ => None,
+        }
+    }
+    let mut factors = Vec::new();
+    for twj in from {
+        factors.push(plain_table(&twj.relation)?);
+        for join in &twj.joins {
+            // An ARRAY JOIN operand parses as a table factor but is an array
+            // column, not a relation — never a view over base tables.
+            if matches!(
+                join.join_operator,
+                JoinOperator::ArrayJoin
+                    | JoinOperator::LeftArrayJoin
+                    | JoinOperator::InnerArrayJoin
+            ) {
+                return None;
+            }
+            factors.push(plain_table(&join.relation)?);
+        }
+    }
+    Some(InsertTargetView { select, factors })
+}
+
+/// The single base table of a shape-gated inline view
+/// ([`insert_target_view`]), when the FROM is exactly one plain table — the
+/// shape-determined case a plain identity parse can resolve. A join view
+/// returns `None`: its base table is whichever relation the projection's
+/// columns attribute to, which needs the binder (qualifier / catalog
+/// resolution).
+pub(crate) fn insert_target_base<'a>(view: &InsertTargetView<'a>) -> Option<&'a ObjectName> {
+    match view.factors.as_slice() {
+        [(name, _)] => Some(name),
         _ => None,
     }
 }
@@ -765,5 +816,26 @@ mod tests {
             TableReference::try_from(&join),
             Err(Error::AnalysisError(_))
         ));
+    }
+
+    #[test]
+    fn insert_target_view_rejects_an_array_join_operand() {
+        // An ARRAY JOIN operand parses as a table factor but is an array
+        // column, not a relation — the gate must reject it so it can't
+        // masquerade as a companion table. No current dialect parses both an
+        // inline-view INSERT target *and* ARRAY JOIN, so this exercises the
+        // gate directly on a ClickHouse-parsed SELECT.
+        use sqlparser::dialect::ClickHouseDialect;
+        let parse = |sql: &str| {
+            let mut stmts = Parser::parse_sql(&ClickHouseDialect {}, sql).unwrap();
+            let Statement::Query(query) = stmts.remove(0) else {
+                panic!("expected a query");
+            };
+            query
+        };
+        let plain = parse("SELECT e.id FROM emp e JOIN dept d ON e.id = d.id");
+        assert!(insert_target_view(&plain).is_some());
+        let array_join = parse("SELECT e.id FROM emp e ARRAY JOIN arr");
+        assert!(insert_target_view(&array_join).is_none());
     }
 }

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -683,11 +683,7 @@ impl<'a> Binder<'a> {
         alias: Option<Ident>,
     ) -> (LogicalPlan, Scope) {
         let m = self.table_match(written);
-        let columns = if m.columns.is_empty() {
-            Columns::Unknown
-        } else {
-            Columns::Cataloged(m.columns)
-        };
+        let columns = Columns::from_catalog(m.columns);
         let scan = LogicalPlan::Scan(Scan {
             table: m.table.clone(),
             resolution: m.resolution,

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -142,7 +142,7 @@ impl<'a> Binder<'a> {
                         // enforces). The base table may be aliased
                         // (`FROM emp e`); the predicate then qualifies through
                         // the alias (`e.dept`), so carry it on the scope.
-                        let predicate = match view.select.selection.as_ref() {
+                        let predicate = match view.selection {
                             Some(predicate) => {
                                 let alias = view.factors[0].1.cloned();
                                 let scope = self.target_scope_with_alias(&m.table, alias);
@@ -152,7 +152,7 @@ impl<'a> Binder<'a> {
                         };
                         (
                             m,
-                            view_target_columns(view.select),
+                            view_target_columns(view.projection),
                             predicate,
                             LogicalPlan::Empty,
                         )
@@ -331,7 +331,6 @@ impl<'a> Binder<'a> {
         &mut self,
         view: &crate::reference::InsertTargetView<'_>,
     ) -> Option<(TableMatch, Vec<Ident>, Vec<Expr>, LogicalPlan)> {
-        let select = view.select;
         // The view's relations — the shape gate already extracted every
         // factor's (name, alias). Each match keeps its written (pre-canonical)
         // reference for the CTE-target check below. A *companion* factor
@@ -358,7 +357,7 @@ impl<'a> Binder<'a> {
         // Each projected column, split as (qualifier, column name) — plain
         // columns only; anything else leaves the target (and the positional
         // pairing) indeterminate.
-        let parts_list: Vec<(Vec<Ident>, Ident)> = select
+        let parts_list: Vec<(Vec<Ident>, Ident)> = view
             .projection
             .iter()
             .map(|item| match item {
@@ -423,12 +422,11 @@ impl<'a> Binder<'a> {
         // ON + WHERE are filter reads over the full view scope (all relations,
         // aliases included).
         let scope = Scope::from_relations(&relations);
-        let predicate = select
-            .from
+        let predicate = view
+            .join_operators
             .iter()
-            .flat_map(|twj| &twj.joins)
-            .filter_map(|j| join_on(&j.join_operator))
-            .chain(select.selection.as_ref())
+            .filter_map(|op| join_on(op))
+            .chain(view.selection)
             .map(|on| self.bind_expr(on, &scope))
             .collect();
         let columns = parts_list
@@ -1535,9 +1533,9 @@ fn is_join_factor(factor: &TableFactor) -> bool {
 /// indeterminate as a whole, so the caller falls back to the column-less
 /// (catalog-fill / diagnostic) path. The `SelectItem` match is exhaustive so a
 /// new variant forces a decision here.
-fn view_target_columns(select: &sqlparser::ast::Select) -> Vec<Ident> {
+fn view_target_columns(projection: &[SelectItem]) -> Vec<Ident> {
     let mut columns = Vec::new();
-    for item in &select.projection {
+    for item in projection {
         let expr = match item {
             SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => expr,
             SelectItem::ExprWithAliases { .. }

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -322,9 +322,9 @@ impl<'a> Binder<'a> {
     /// `None` — the caller flags and drops — when no single target is
     /// determined: a non-column projection item (a wildcard / expression), a
     /// column that is ambiguous / unresolved / owned by a different relation
-    /// than its siblings. Real Oracle rejects those shapes too (the INTO
-    /// columns must all belong to one key-preserved table), so no side is
-    /// fabricated. Key-preservedness itself isn't *verified* (that needs
+    /// than its siblings, or any factor naming a declared CTE (not a base
+    /// table). Real Oracle rejects those shapes too (the INTO columns must
+    /// all belong to one key-preserved table), so no side is fabricated. Key-preservedness itself isn't *verified* (that needs
     /// unique-key metadata the catalog doesn't carry) — attribution assumes a
     /// valid statement.
     fn bind_join_view_target(
@@ -332,23 +332,28 @@ impl<'a> Binder<'a> {
         view: &crate::reference::InsertTargetView<'_>,
     ) -> Option<(TableMatch, Vec<Ident>, Vec<Expr>, LogicalPlan)> {
         // The view's relations — the shape gate already extracted every
-        // factor's (name, alias). Each match keeps its written (pre-canonical)
-        // reference for the CTE-target check below. A *companion* factor
-        // naming a declared CTE is left as a best-effort scan (the normal FROM
-        // path would expand a `CteRef`; a CTE inside an insert-target view is
-        // beyond exotic).
-        let mut matches: Vec<(TableReference, TableMatch)> = Vec::new();
+        // factor's (name, alias). A factor naming a declared CTE — target or
+        // companion — makes the view not-a-view-over-base-tables: flag and
+        // drop the whole statement rather than surface the CTE name as a
+        // phantom base-table read (binding it as a real `CteRef` is possible,
+        // but no engine executes a WITH + inline-view-target INSERT, so the
+        // machinery isn't worth it until one does).
+        let mut matches: Vec<TableMatch> = Vec::new();
         for (name, _) in &view.factors {
             // An unrepresentable name flags itself inside `table_ref`.
             let written = self.table_ref(name)?;
             let m = self.table_match(&written);
-            matches.push((written, m));
+            if m.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
+                self.record_unsupported_dml_target("INSERT", &written);
+                return None;
+            }
+            matches.push(m);
         }
         let relations: Vec<Relation> = view
             .factors
             .iter()
             .zip(&matches)
-            .map(|((_, alias), (_, m))| Relation::Table {
+            .map(|((_, alias), m)| Relation::Table {
                 alias: alias.cloned(),
                 table: m.table.clone(),
                 columns: Columns::from_catalog(m.columns.clone()),
@@ -400,18 +405,11 @@ impl<'a> Binder<'a> {
         // always names one of the view's relations.
         let position = matches
             .iter()
-            .position(|(_, m)| self.table_identity_eq(&m.table, &target))?;
-        let (written, target_match) = matches.remove(position);
-        // The target is a real table, never a CTE (like `named_insert_target`
-        // — you can't INSERT into a read-only CTE): flag and drop rather than
-        // fabricate a write.
-        if target_match.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
-            self.record_unsupported_dml_target("INSERT", &written);
-            return None;
-        }
+            .position(|m| self.table_identity_eq(&m.table, &target))?;
+        let target_match = matches.remove(position);
         let context = matches
             .into_iter()
-            .map(|(_, m)| {
+            .map(|m| {
                 LogicalPlan::Scan(Scan {
                     table: m.table,
                     resolution: m.resolution,

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -3,6 +3,7 @@
 //! [`LogicalPlan`] root, plus the write-target resolution helpers (DELETE
 //! multi-target identity, RETURNING projection, ON CONFLICT).
 
+use super::resolve::TableMatch;
 use super::*;
 
 impl<'a> Binder<'a> {
@@ -104,34 +105,75 @@ impl<'a> Binder<'a> {
     /// expression is dropped (not flagged: it isn't an analyzable-info loss the
     /// common, constant case would false-alarm on).
     pub(super) fn bind_insert(&mut self, insert: &SqlInsert) -> LogicalPlan {
-        let (name, view) = match &insert.table {
-            TableObject::TableName(name) => (name, None),
-            TableObject::TableFunction(function) => (&function.name, None),
+        // Resolve the target into its catalog match plus, for an Oracle
+        // inline-view target, the view's pieces: its projected column names
+        // (the explicit target columns), its bound ON / WHERE predicates
+        // (filter reads), and — for a join view — the companion relations.
+        let (m, view_columns, target_predicate, target_context) = match &insert.table {
+            TableObject::TableName(name) => match self.named_insert_target(name) {
+                Some(m) => (m, Vec::new(), Vec::new(), LogicalPlan::Empty),
+                None => return LogicalPlan::Empty,
+            },
+            TableObject::TableFunction(function) => {
+                match self.named_insert_target(&function.name) {
+                    Some(m) => (m, Vec::new(), Vec::new(), LogicalPlan::Empty),
+                    None => return LogicalPlan::Empty,
+                }
+            }
             // Oracle `INSERT INTO (SELECT …) …`: an inline-view target — the
-            // row lands in the view's single base table, so resolve through to
-            // it (the projection names the target columns, the WHERE is filter
-            // reads). A view over no single base table (a join — key-preserved
-            // rules need a catalog — or a set operation) is dropped + flagged
-            // like a CTE / derived target.
-            TableObject::TableQuery(query) => match crate::reference::insert_target_view(query) {
-                Some((name, select)) => (name, Some(select)),
-                None => {
+            // row lands in the view's base table. A single-table view is
+            // shape-determined; a join view's base table is whichever relation
+            // every projected column attributes to. A view the gate rejects
+            // (a non-table factor, a set operation, any other clause) — or a
+            // join view with no single determined target — is dropped +
+            // flagged like a CTE / derived target.
+            TableObject::TableQuery(query) => {
+                let Some(view) = crate::reference::insert_target_view(query) else {
                     self.record_unsupported_dml_target("INSERT", query.as_ref());
                     return LogicalPlan::Empty;
+                };
+                match crate::reference::insert_target_base(&view) {
+                    Some(name) => {
+                        let Some(m) = self.named_insert_target(name) else {
+                            return LogicalPlan::Empty;
+                        };
+                        // The WHERE resolves against the target alone (filter
+                        // reads — e.g. the predicate a `WITH CHECK OPTION`
+                        // enforces). The base table may be aliased
+                        // (`FROM emp e`); the predicate then qualifies through
+                        // the alias (`e.dept`), so carry it on the scope.
+                        let predicate = match view.select.selection.as_ref() {
+                            Some(predicate) => {
+                                let alias = view.factors[0].1.cloned();
+                                let scope = self.target_scope_with_alias(&m.table, alias);
+                                vec![self.bind_expr(predicate, &scope)]
+                            }
+                            None => Vec::new(),
+                        };
+                        (
+                            m,
+                            view_target_columns(view.select),
+                            predicate,
+                            LogicalPlan::Empty,
+                        )
+                    }
+                    None => {
+                        let diagnostics_before = self.diagnostics.len();
+                        match self.bind_join_view_target(&view) {
+                            Some(resolved) => resolved,
+                            None => {
+                                // A factor that failed to resolve already
+                                // flagged itself; flag only when nothing was.
+                                if self.diagnostics.len() == diagnostics_before {
+                                    self.record_unsupported_dml_target("INSERT", query.as_ref());
+                                }
+                                return LogicalPlan::Empty;
+                            }
+                        }
+                    }
                 }
-            },
+            }
         };
-        let Some(written) = self.table_ref(name) else {
-            return LogicalPlan::Empty;
-        };
-        let m = self.table_match(&written);
-        // The target is a real table, never a CTE (you can't INSERT into a
-        // read-only CTE): a name that matches a declared CTE and isn't a catalog
-        // table is the CTE — flag and drop rather than fabricate a write.
-        if m.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
-            self.record_unsupported_dml_target("INSERT", &written);
-            return LogicalPlan::Empty;
-        }
         let target = m.table;
         // MySQL `INSERT INTO t SET col = expr, …`: the assignment form (no
         // VALUES / SELECT source) — each assignment is a value column named by
@@ -175,7 +217,7 @@ impl<'a> Binder<'a> {
                 .filter_map(|n| n.0.last().and_then(|p| p.as_ident().cloned()))
                 .collect()
         } else {
-            view.map(view_target_columns).unwrap_or_default()
+            view_columns
         };
         let has_explicit = !explicit.is_empty();
         let columns = if has_explicit {
@@ -229,23 +271,6 @@ impl<'a> Binder<'a> {
             Some(on) => self.bind_conflict(on, &target, &columns),
             None => (Vec::new(), Vec::new()),
         };
-        // An inline-view target's WHERE resolves against the target alone
-        // (filter reads — e.g. the predicate a `WITH CHECK OPTION` enforces).
-        // The base table may be aliased (`FROM emp e`); the predicate then
-        // qualifies through the alias (`e.dept`), so carry it on the scope.
-        let target_predicate = match view.and_then(|v| v.selection.as_ref()) {
-            Some(predicate) => {
-                let alias = view
-                    .and_then(|v| v.from.first())
-                    .and_then(|f| match &f.relation {
-                        TableFactor::Table { alias, .. } => alias.as_ref().map(|a| a.name.clone()),
-                        _ => None,
-                    });
-                let scope = self.target_scope_with_alias(&target, alias);
-                vec![self.bind_expr(predicate, &scope)]
-            }
-            None => Vec::new(),
-        };
         // RETURNING resolves against the target alone (the source query's
         // scope is already popped).
         let returning = self.bind_returning(&insert.returning, &self.target_scope(&target));
@@ -264,8 +289,153 @@ impl<'a> Binder<'a> {
             on_conflict,
             conflict_predicate,
             target_predicate,
+            target_context: Box::new(target_context),
             source_wildcard,
         })
+    }
+
+    /// Resolve a plain named INSERT target: `table_ref` + catalog match. The
+    /// target is a real table, never a CTE (you can't INSERT into a read-only
+    /// CTE): a name that matches a declared CTE and isn't a catalog table is
+    /// the CTE — flag and drop rather than fabricate a write.
+    fn named_insert_target(&mut self, name: &ObjectName) -> Option<TableMatch> {
+        let written = self.table_ref(name)?;
+        let m = self.table_match(&written);
+        if m.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
+            self.record_unsupported_dml_target("INSERT", &written);
+            return None;
+        }
+        Some(m)
+    }
+
+    /// Resolve an Oracle **join-view** INSERT target: bind every FROM factor
+    /// as a relation, then attribute each projected column — a qualifier
+    /// resolves it text-only (like a multi-table UPDATE's `SET t2.col`), an
+    /// unqualified column by the catalog-owner rule
+    /// ([`unqualified_write_binding`](Self::unqualified_write_binding)) — and
+    /// the row lands in the one relation **every** column agrees on. Returns
+    /// that target's match, the projected column names (the explicit target
+    /// columns), the bound ON + WHERE predicates (filter reads over the view's
+    /// relations), and the companion relations as scanned context
+    /// ([`Insert::target_context`]).
+    ///
+    /// `None` — the caller flags and drops — when no single target is
+    /// determined: a non-column projection item (a wildcard / expression), a
+    /// column that is ambiguous / unresolved / owned by a different relation
+    /// than its siblings. Real Oracle rejects those shapes too (the INTO
+    /// columns must all belong to one key-preserved table), so no side is
+    /// fabricated. Key-preservedness itself isn't *verified* (that needs
+    /// unique-key metadata the catalog doesn't carry) — attribution assumes a
+    /// valid statement.
+    fn bind_join_view_target(
+        &mut self,
+        view: &crate::reference::InsertTargetView<'_>,
+    ) -> Option<(TableMatch, Vec<Ident>, Vec<Expr>, LogicalPlan)> {
+        let select = view.select;
+        // The view's relations — the shape gate already extracted every
+        // factor's (name, alias). Each match keeps its written (pre-canonical)
+        // reference for the CTE-target check below. A *companion* factor
+        // naming a declared CTE is left as a best-effort scan (the normal FROM
+        // path would expand a `CteRef`; a CTE inside an insert-target view is
+        // beyond exotic).
+        let mut matches: Vec<(TableReference, TableMatch)> = Vec::new();
+        for (name, _) in &view.factors {
+            // An unrepresentable name flags itself inside `table_ref`.
+            let written = self.table_ref(name)?;
+            let m = self.table_match(&written);
+            matches.push((written, m));
+        }
+        let relations: Vec<Relation> = view
+            .factors
+            .iter()
+            .zip(&matches)
+            .map(|((_, alias), (_, m))| Relation::Table {
+                alias: alias.cloned(),
+                table: m.table.clone(),
+                columns: Columns::from_catalog(m.columns.clone()),
+            })
+            .collect();
+        // Each projected column, split as (qualifier, column name) — plain
+        // columns only; anything else leaves the target (and the positional
+        // pairing) indeterminate.
+        let parts_list: Vec<(Vec<Ident>, Ident)> = select
+            .projection
+            .iter()
+            .map(|item| match item {
+                SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
+                    match expr {
+                        SqlExpr::Identifier(id) => Some((Vec::new(), id.clone())),
+                        SqlExpr::CompoundIdentifier(parts) => parts
+                            .split_last()
+                            .map(|(column, qualifier)| (qualifier.to_vec(), column.clone())),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            })
+            .collect::<Option<_>>()?;
+        // Attribute every column — a qualified one text-only via its
+        // qualifier, an unqualified one by the catalog-owner rule — and
+        // require all to agree on the first column's relation. (An empty
+        // projection can't parse.)
+        let mut owners = parts_list.iter().map(|(qualifier, column)| {
+            if qualifier.is_empty() {
+                match self.unqualified_write_binding(column, &relations)? {
+                    Binding::Base { table, .. } => Some(table),
+                    _ => None,
+                }
+            } else {
+                relations
+                    .iter()
+                    .find_map(|rel| self.writable_qualifier_table(rel, qualifier))
+            }
+        });
+        let target = owners.next()??;
+        for owner in owners {
+            if !self.table_identity_eq(&target, &owner?) {
+                return None; // columns straddle two relations
+            }
+        }
+        // Split off the (first) target relation; the companions become
+        // scanned context (reads, but no data feed). The attributed target
+        // always names one of the view's relations.
+        let position = matches
+            .iter()
+            .position(|(_, m)| self.table_identity_eq(&m.table, &target))?;
+        let (written, target_match) = matches.remove(position);
+        // The target is a real table, never a CTE (like `named_insert_target`
+        // — you can't INSERT into a read-only CTE): flag and drop rather than
+        // fabricate a write.
+        if target_match.resolution != ResolutionKind::Cataloged && self.is_declared_cte(&written) {
+            self.record_unsupported_dml_target("INSERT", &written);
+            return None;
+        }
+        let context = matches
+            .into_iter()
+            .map(|(_, m)| {
+                LogicalPlan::Scan(Scan {
+                    table: m.table,
+                    resolution: m.resolution,
+                })
+            })
+            .reduce(|left, right| join(left, right, Vec::new()))
+            .unwrap_or(LogicalPlan::Empty);
+        // ON + WHERE are filter reads over the full view scope (all relations,
+        // aliases included).
+        let scope = Scope::from_relations(&relations);
+        let predicate = select
+            .from
+            .iter()
+            .flat_map(|twj| &twj.joins)
+            .filter_map(|j| join_on(&j.join_operator))
+            .chain(select.selection.as_ref())
+            .map(|on| self.bind_expr(on, &scope))
+            .collect();
+        let columns = parts_list
+            .iter()
+            .map(|(_, column)| column.clone())
+            .collect();
+        Some((target_match, columns, predicate, context))
     }
 
     /// Wrap written column names as [`ColumnWrite`]s, each resolved against the
@@ -337,8 +507,9 @@ impl<'a> Binder<'a> {
             on_conflict,
             conflict_predicate,
             // The MySQL SET form has no inline-view target and no source
-            // query, so no target predicate / wildcard.
+            // query, so no target predicate / context / wildcard.
             target_predicate: Vec::new(),
+            target_context: Box::new(LogicalPlan::Empty),
             source_wildcard: false,
         })
     }
@@ -905,11 +1076,7 @@ impl<'a> Binder<'a> {
         alias: Option<Ident>,
     ) -> Scope {
         let m = self.table_match(target);
-        let columns = if m.columns.is_empty() {
-            Columns::Unknown
-        } else {
-            Columns::Cataloged(m.columns)
-        };
+        let columns = Columns::from_catalog(m.columns);
         Scope::single(Relation::Table {
             alias,
             table: m.table,

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -69,6 +69,19 @@ pub(crate) enum Columns {
     Unknown,
 }
 
+impl Columns {
+    /// A catalog match's column list as scope knowledge — `table_match`
+    /// returns an empty list for a miss (schema unknown), never a zero-column
+    /// table, so empty maps to [`Unknown`](Columns::Unknown).
+    pub(crate) fn from_catalog(columns: Vec<Ident>) -> Columns {
+        if columns.is_empty() {
+            Columns::Unknown
+        } else {
+            Columns::Cataloged(columns)
+        }
+    }
+}
+
 /// Selection (σ): rows passing `predicate` flow through unchanged. The
 /// predicate's columns are reads but never lineage origins — it is filter
 /// position, and `origins` never traces here.
@@ -224,10 +237,18 @@ pub(crate) struct Insert {
     pub(crate) returning: Vec<NamedExpr>,
     pub(crate) on_conflict: Vec<Assignment>,
     pub(crate) conflict_predicate: Vec<Expr>,
-    /// An Oracle inline-view target's WHERE predicate
-    /// (`INSERT INTO (SELECT … FROM t WHERE …) …`): filter reads against the
-    /// target — its columns read, but never originate a value.
+    /// An Oracle inline-view target's predicates — the WHERE
+    /// (`INSERT INTO (SELECT … FROM t WHERE …) …`) plus, for a join view, the
+    /// join `ON` conditions: filter reads against the view's relations — their
+    /// columns read, but never originate a value.
     pub(crate) target_predicate: Vec<Expr>,
+    /// An Oracle **join-view** target's companion relations — the joined
+    /// tables other than the write target (`INSERT INTO (SELECT e.id FROM
+    /// emp e JOIN dept d ON …) …` → `Scan(dept)`): scanned context that gates
+    /// which rows the view exposes, so they surface as table *reads* — but
+    /// they feed no data (the value path is `input`), so table lineage
+    /// ignores them. [`Empty`](LogicalPlan::Empty) for every other INSERT.
+    pub(crate) target_context: Box<LogicalPlan>,
     pub(crate) source_wildcard: bool,
 }
 
@@ -716,7 +737,7 @@ pub(super) fn children(op: &LogicalPlan) -> Vec<&LogicalPlan> {
         // args are own expressions.
         LogicalPlan::TableFunction(tf) => vec![&tf.input],
         LogicalPlan::With(w) => vec![&w.body],
-        LogicalPlan::Insert(i) => vec![&i.input],
+        LogicalPlan::Insert(i) => vec![&i.input, &i.target_context],
         LogicalPlan::Update(u) => vec![&u.input],
         LogicalPlan::Delete(d) => vec![&d.input],
         LogicalPlan::Merge(m) => vec![&m.source],

--- a/sql-insight/tests/column_operation_extractor/diagnostics.rs
+++ b/sql-insight/tests/column_operation_extractor/diagnostics.rs
@@ -52,16 +52,17 @@ mod reported {
     }
 
     #[test]
-    fn insert_into_join_view_target_reports_diagnostic() {
-        // Oracle `INSERT INTO (SELECT … JOIN …) …`: a join view names no single
-        // base table SQL text can determine (key-preserved rules need a
-        // catalog) — flagged (like the non-table UPDATE / MERGE target above),
-        // not dropped silently. The statement_kind stays Insert; nothing is
-        // written. (A *single-table* inline view resolves through to its base
-        // table instead — see `writes_deletes::insert_inline_view_target`.)
+    fn insert_into_undetermined_join_view_target_reports_diagnostic() {
+        // Oracle `INSERT INTO (SELECT … JOIN …) …` resolves when every
+        // projected column attributes to one relation (see
+        // `writes_deletes::insert_inline_view_target`); a view whose target
+        // can't be determined — here an unqualified column with no catalog —
+        // is flagged (like the non-table UPDATE / MERGE target above), not
+        // dropped silently. The statement_kind stays Insert; nothing is
+        // written.
         assert_column_ops_with_dialect(
             &OracleDialect {},
-            "INSERT INTO (SELECT e.id FROM emp e JOIN dept d ON e.dept = d.id) VALUES (1)",
+            "INSERT INTO (SELECT id FROM emp e JOIN dept d ON e.dept = d.id) VALUES (1)",
             ColumnOperation {
                 statement_kind: StatementKind::Insert,
                 reads: vec![],

--- a/sql-insight/tests/column_operation_extractor/resolution.rs
+++ b/sql-insight/tests/column_operation_extractor/resolution.rs
@@ -497,6 +497,35 @@ mod catalog_strict {
         );
     }
 
+    #[test]
+    fn join_view_insert_unqualified_projection_attributes_by_catalog_owner() {
+        // An Oracle join-view INSERT with an *unqualified* projection: the
+        // catalog-owner rule attributes each column — `name` / `dept_id` are
+        // listed only in EMP, so the row lands there; DEPT stays a scanned
+        // companion. (Oracle folds unquoted identifiers to upper case, so the
+        // catalog registers upper-cased names.)
+        use sql_insight::sqlparser::dialect::OracleDialect;
+        let catalog = TestCatalog::default()
+            .with("EMP", vec!["ID", "NAME", "DEPT_ID"])
+            .with("DEPT", vec!["ID", "ACTIVE"]);
+        assert_column_ops_with_catalog_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT name, dept_id FROM emp JOIN dept \
+             ON emp.dept_id = dept.id) VALUES ('x', 1)",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![
+                    read_confirmed("EMP", "dept_id"),
+                    read_confirmed("DEPT", "id"),
+                ],
+                writes: vec![write("EMP", "name"), write("EMP", "dept_id")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
     // ===== unqualified SET write attribution =============================
     //
     // An unqualified SET target in a *multi-table* UPDATE is attributed with

--- a/sql-insight/tests/column_operation_extractor/writes_deletes.rs
+++ b/sql-insight/tests/column_operation_extractor/writes_deletes.rs
@@ -409,6 +409,258 @@ mod insert_inline_view_target {
     }
 
     #[test]
+    fn join_view_qualified_projection_resolves_the_common_relation() {
+        // A join view: every projected column is qualified to `e` — the row
+        // lands in `emp` (text-only attribution, like a multi-table UPDATE's
+        // `SET t2.col`). The companion `dept` is scanned context; the ON and
+        // WHERE are filter reads over both relations.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id, e.name FROM emp e JOIN dept d \
+             ON e.dept_id = d.id WHERE d.active = 1) VALUES (100, 'x')",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![
+                    read("emp", "dept_id"),
+                    read("dept", "id"),
+                    read("dept", "active"),
+                ],
+                writes: vec![write("emp", "id"), write("emp", "name")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_comma_form_resolves_too() {
+        // The classic Oracle comma-join spelling of the same view.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id FROM emp e, dept d WHERE e.dept_id = d.id) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp", "dept_id"), read("dept", "id")],
+                writes: vec![write("emp", "id")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_select_source_traces_to_the_base_column() {
+        // Relation lineage pairs the source outputs with the resolved base
+        // columns — through the join view.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id FROM emp e JOIN dept d ON e.dept_id = d.id) \
+             SELECT x FROM s",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp", "dept_id"), read("dept", "id"), read("s", "x")],
+                writes: vec![write("emp", "id")],
+                lineage: vec![passthrough(col("s", "x"), relation("emp", "id"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_using_clause_adds_no_reads() {
+        // `USING (dept_id)` names merge columns, not reads — consistent with
+        // the SELECT path, where reads come from *reference* sites (a fan-in),
+        // never the USING clause itself. The view still resolves to `emp`.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id FROM emp e JOIN dept d USING (dept_id)) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![write("emp", "id")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_self_join_resolves_to_the_one_table() {
+        // A self-join view: both instances are the same table, so columns
+        // qualified through either alias agree on `emp` — the identity is
+        // right even though key-preservedness is per-instance (unverifiable
+        // without key metadata). The second instance stays a scanned
+        // companion, so `emp` reads through it too.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e1.id, e2.name FROM emp e1 JOIN emp e2 \
+             ON e1.id = e2.id) VALUES (1, 'x')",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp", "id"), read("emp", "id")],
+                writes: vec![write("emp", "id"), write("emp", "name")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_wildcard_projection_is_flagged() {
+        // A wildcard projection names no attributable columns — the target
+        // (and the positional pairing) is indeterminate: flag + drop.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT * FROM emp e JOIN dept d ON e.id = d.id) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn from_less_view_is_flagged() {
+        // `(SELECT 1)` has no FROM — no base table exists: flag + drop.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT 1) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn derived_factor_in_view_is_flagged() {
+        // A derived table as the view's FROM factor (single or joined) is not
+        // a plain base table — the gate rejects both shapes.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT x.a FROM (SELECT a FROM t) x) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id FROM emp e JOIN (SELECT 1 AS id) d ON e.id = d.id) \
+             VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn single_table_view_over_a_cte_is_flagged() {
+        // The single-table view path takes the same CTE-target check as a
+        // plain-name INSERT — a CTE is read-only.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "WITH c AS (SELECT 1 AS a FROM x) INSERT INTO (SELECT a FROM c) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_expression_projection_is_flagged() {
+        // A non-column projection item (`e.id + 1`) leaves the join view's
+        // target indeterminate — unlike the single-table view (whose base is
+        // shape-determined and falls to the column-less path), a join view
+        // needs every column attributable: flag + drop.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id + 1 FROM emp e JOIN dept d ON e.id = d.id) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_cte_target_is_flagged_not_written() {
+        // The attributed target names a declared CTE — a read-only relation,
+        // never a write target (the single-table view and plain-name INSERT
+        // paths flag the same shape): flag + drop rather than fabricate a
+        // write to `c`.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "WITH c AS (SELECT 1 AS id FROM x) \
+             INSERT INTO (SELECT c2.id FROM c c2 JOIN emp e ON c2.id = e.id) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_straddling_columns_are_flagged() {
+        // The projected columns attribute to *different* relations — no single
+        // table receives the row (real Oracle rejects this shape: the INTO
+        // columns must belong to one key-preserved table) — flag + drop.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT e.id, d.active FROM emp e JOIN dept d \
+             ON e.dept_id = d.id) VALUES (1, 1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_unqualified_without_catalog_is_flagged() {
+        // Catalog-free, an unqualified projected column has no determinable
+        // owner among the joined relations — flag + drop (the catalog-owner
+        // rule resolves it when a catalog lists it in exactly one relation).
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (SELECT id FROM emp JOIN dept ON emp.dept_id = dept.id) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
     fn view_with_other_clauses_is_flagged_not_resolved() {
         // Only the minimal insertable-view shape (projection + FROM + WHERE)
         // resolves through. Any other clause — GROUP BY here, likewise

--- a/sql-insight/tests/column_operation_extractor/writes_deletes.rs
+++ b/sql-insight/tests/column_operation_extractor/writes_deletes.rs
@@ -604,24 +604,21 @@ mod insert_inline_view_target {
     }
 
     #[test]
-    fn join_view_resolves_when_a_cte_is_only_a_companion() {
-        // A declared CTE in the view's FROM is fine as long as the *target*
-        // attributes to a real base table — the CTE-target check gates the
-        // write, not the whole view. The companion CTE stays a best-effort
-        // scan (its reference reads surface against the CTE's own name, not
-        // through its body like a `CteRef` would — documented compromise),
-        // and the CTE body's reads surface via the usual unreferenced-CTE
-        // rule.
+    fn join_view_with_a_cte_factor_is_flagged() {
+        // A factor naming a declared CTE — even as a mere companion — makes
+        // the view not-a-view-over-base-tables: flag + drop the statement
+        // rather than surface the CTE name as a phantom base-table read.
+        // (No engine executes a WITH + inline-view-target INSERT anyway.)
         assert_column_ops_with_dialect(
             &OracleDialect {},
             "WITH c AS (SELECT 1 AS id FROM x) \
              INSERT INTO (SELECT e.name FROM emp e JOIN c ON e.id = c.id) VALUES ('a')",
             ColumnOperation {
                 statement_kind: StatementKind::Insert,
-                reads: vec![read("emp", "id"), read("c", "id")],
-                writes: vec![write("emp", "name")],
+                reads: vec![],
+                writes: vec![],
                 lineage: vec![],
-                diagnostics: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
             },
         );
     }

--- a/sql-insight/tests/column_operation_extractor/writes_deletes.rs
+++ b/sql-insight/tests/column_operation_extractor/writes_deletes.rs
@@ -604,6 +604,69 @@ mod insert_inline_view_target {
     }
 
     #[test]
+    fn join_view_resolves_when_a_cte_is_only_a_companion() {
+        // A declared CTE in the view's FROM is fine as long as the *target*
+        // attributes to a real base table — the CTE-target check gates the
+        // write, not the whole view. The companion CTE stays a best-effort
+        // scan (its reference reads surface against the CTE's own name, not
+        // through its body like a `CteRef` would — documented compromise),
+        // and the CTE body's reads surface via the usual unreferenced-CTE
+        // rule.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "WITH c AS (SELECT 1 AS id FROM x) \
+             INSERT INTO (SELECT e.name FROM emp e JOIN c ON e.id = c.id) VALUES ('a')",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp", "id"), read("c", "id")],
+                writes: vec![write("emp", "name")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn join_view_with_a_top_level_cte_source_traces_through_it() {
+        // A top-level CTE consumed only by the *source* interacts with the
+        // join view exactly like any source: the CTE reference resolves
+        // through its body (`c.n → x.n`), and relation lineage lands on the
+        // attributed base table.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "WITH c AS (SELECT n FROM x) \
+             INSERT INTO (SELECT e.name FROM emp e JOIN dept d ON e.dept_id = d.id) \
+             SELECT n FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("x", "n"), read("emp", "dept_id"), read("dept", "id")],
+                writes: vec![write("emp", "name")],
+                lineage: vec![passthrough(col("x", "n"), relation("emp", "name"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn cte_inside_the_target_view_is_flagged() {
+        // A WITH *inside* the target view is rejected by the shape gate
+        // (`with: None`) — its CTE could shadow a FROM name, so resolving
+        // through it would need full CTE machinery: flag + drop.
+        assert_column_ops_with_dialect(
+            &OracleDialect {},
+            "INSERT INTO (WITH c AS (SELECT 1 AS id FROM x) \
+             SELECT e.id FROM emp e JOIN dept d ON e.id = d.id) VALUES (1)",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::UnsupportedStatement)],
+            },
+        );
+    }
+
+    #[test]
     fn join_view_cte_target_is_flagged_not_written() {
         // The attributed target names a declared CTE — a read-only relation,
         // never a write target (the single-table view and plain-name INSERT

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -451,6 +451,55 @@ mod insert_statement {
     }
 
     #[test]
+    fn test_insert_into_join_view_reads_the_companion_table() {
+        // A resolved join-view INSERT: the row lands in `emp` (create), and
+        // both view relations are reads — `emp` via its referenced columns
+        // (the sink rule), `dept` as scanned companion context.
+        use sql_insight::sqlparser::dialect::OracleDialect;
+        let sql = "INSERT INTO (SELECT e.id FROM emp e JOIN dept d \
+                   ON e.dept_id = d.id WHERE d.active = 1) VALUES (100)";
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("emp"))],
+            read_tables: vec![cread(table("emp")), cread(table("dept"))],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(sql, expected, vec![Box::new(OracleDialect {})]);
+    }
+
+    #[test]
+    fn test_insert_into_table_function_targets_the_function_name() {
+        // ClickHouse `INSERT INTO TABLE FUNCTION remote(…)`: the function's
+        // name stands in as the write target (best-effort — the real remote
+        // table isn't inspectable from SQL text).
+        use sql_insight::sqlparser::dialect::ClickHouseDialect;
+        let sql = "INSERT INTO TABLE FUNCTION remote('addr', db.tbl) VALUES (1)";
+        let result = CrudTableExtractor::extract(&ClickHouseDialect {}, sql).unwrap();
+        let crud = result.into_iter().next().unwrap().unwrap();
+        assert_eq!(crud.create_tables, vec![cwrite(table("remote"))]);
+        assert_eq!(crud.read_tables, vec![]);
+    }
+
+    #[test]
+    fn test_insert_into_table_function_with_unrepresentable_name_drops() {
+        // A TABLE FUNCTION whose name exceeds `catalog.schema.name` can't be
+        // represented — dropped with the usual TooManyTableQualifiers flag.
+        use sql_insight::diagnostic::TableLevelDiagnosticKind;
+        use sql_insight::sqlparser::dialect::ClickHouseDialect;
+        let sql = "INSERT INTO TABLE FUNCTION a.b.c.d('x') VALUES (1)";
+        let result = CrudTableExtractor::extract(&ClickHouseDialect {}, sql).unwrap();
+        let crud = result.into_iter().next().unwrap().unwrap();
+        assert_eq!(crud.create_tables, vec![]);
+        assert_eq!(crud.read_tables, vec![]);
+        assert_eq!(crud.diagnostics.len(), 1);
+        assert_eq!(
+            crud.diagnostics[0].kind,
+            TableLevelDiagnosticKind::TooManyTableQualifiers
+        );
+    }
+
+    #[test]
     fn test_parenthesized_insert_keeps_the_insert_verb() {
         // `(INSERT … SELECT …)` keeps its verb → target buckets as Create,
         // source as Read (the misclassification dropped both into a Select).

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -585,6 +585,27 @@ mod ddl {
     }
 
     #[test]
+    fn join_view_insert_companion_reads_but_does_not_feed() {
+        // An Oracle join-view INSERT: the companion `dept` gates which rows
+        // are visible, so it *reads* — but it feeds no data (the value path is
+        // the source), so table lineage carries `s → emp` only, never
+        // `dept → emp`.
+        use sql_insight::sqlparser::dialect::OracleDialect;
+        assert_ops_with(
+            "INSERT INTO (SELECT e.id FROM emp e JOIN dept d ON e.dept_id = d.id) \
+             SELECT x FROM s",
+            &OracleDialect {},
+            TableOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("emp"), read("dept"), read("s")],
+                writes: vec![twrite("emp")],
+                lineage: vec![edge("s", "emp")],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn alter_table_emits_write_only() {
         assert_ops(
             "ALTER TABLE t1 ADD COLUMN a INT",


### PR DESCRIPTION
## Summary

Implements the remaining inline-view deferral from #58 (design agreed in
discussion): an Oracle **join-view** INSERT now resolves to its base table by
**column attribution**, instead of dropping the whole statement.

```sql
INSERT INTO (SELECT e.id, e.name FROM emp e JOIN dept d
             ON e.dept_id = d.id WHERE d.active = 1) VALUES (100, 'x')
-- before: everything empty + UnsupportedStatement
-- after:  create=[emp]  read=[emp, dept]
--         writes=[emp.id, emp.name]
--         reads=[emp.dept_id, dept.id, dept.active]  (ON + WHERE, filter)
```

## Attribution rule (composes two existing mechanisms — no new rules)

The row lands in the one relation **every** projected column agrees on:

| projection column | attribution | precedent |
|---|---|---|
| qualified (`e.id`) | its qualifier, resolved against the view's relations — text-only, no catalog | multi-table UPDATE's `SET t2.col` |
| unqualified (`name`) | the catalog-owner rule (`unqualified_write_binding`, #59) over the view's relations | #59's read-mirrored SET attribution |

Any column ambiguous / unresolved / owned by a different relation than its
siblings — or any factor naming a declared CTE (not a base table) — → drop +
flag as before. Real Oracle rejects those shapes too (the INTO columns must
all belong to one key-preserved table); key-preservedness
itself isn't *verified* — that needs unique-key metadata the catalog doesn't
carry — attribution assumes a valid statement. The classic comma-join
spelling (`FROM emp e, dept d WHERE …`) resolves identically.

## Companion relations: `Insert::target_context`

The joined tables other than the target (here `dept`) become scanned context:

- **table reads** ✓ (`children()` now includes the context, so the scan
  surfaces; `emp` itself keeps the sink rule — it reads because its columns
  are referenced, not via a scan, consistent with the single-table view path)
- **no data feed** ✓ — table lineage's `feeding_scans` walks `input` only,
  matching the semantics (the join gates which rows are visible; the value
  path is the source)
- ON + WHERE land in the existing `target_predicate` (filter reads over the
  full view scope, aliases included)

`TableReference`'s `TryFrom<&Insert>` stays **shape-determined**: the gate
admits joins of plain tables, but a join view's base table needs binder
resolution, so the plain identity parse resolves single-table views only
(documented; join → `Err`).

## Edge cases covered on review

- **CTE factors**: any view factor naming a declared CTE — target (used to
  fabricate a write to the CTE) or companion (used to surface the CTE name as
  a phantom base-table read) — now flags the whole statement, uniformly in
  the factor loop. A WITH *inside* the view stays gate-rejected; a top-level
  CTE consumed only by the source still traces through its body (pinned).
- **USING / NATURAL join views** resolve, and the USING clause itself adds no
  reads — consistent with the SELECT path, where reads come from *reference*
  sites (pinned).
- **Self-join views** resolve to the one table (identity is right;
  key-preservedness is per-instance and unverifiable without key metadata).
- **Table lineage**: the companion never feeds (`s → emp` only, no
  `dept → emp`) — pinned at table level.
- Gate rejections pinned: FROM-less view, derived factor (single and joined),
  wildcard / expression projections, ClickHouse `TABLE FUNCTION` targets
  (moved code) incl. an unrepresentable function name.
- For full patch coverage, the gate hands its proof over **entirely as
  data** (`InsertTargetView { factors, projection, join_operators, selection }`
  — parse-don't-validate): the unreachable defensive arms are *deleted*, and
  no consumer re-reads the `Query`, so `factors` can't be paired with a
  clause it wasn't derived from.

## Tests

Qualified projection (catalog-free), comma form, SELECT-source lineage through
the view (`s.x → emp.id`), straddling columns → flag, unqualified without a
catalog → flag, unqualified **with** a catalog attributing by owner
(Oracle-cased catalog), table-level companion read + lineage, USING /
self-join / gate-rejection pins, all CTE placements (factor → flag, inside
the view → flag, top-level source-only → traces through the body), and the
#58 flag test narrowed to an undetermined shape. All gates green (fmt /
clippy / `test --all` / doc); 788 tests, **100% patch coverage** on source
lines (llvm-cov ∩ diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
