### PR TITLE
ci: credit the author on breaking-change changelog headings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,10 +96,8 @@ Rules that bite if forgotten (the why is in `ARCHITECTURE.md`):
   as the commit subject, which release-plz reads to compute per-crate version
   bumps and changelogs — so `fix:` / `feat:` / `feat!:` (breaking) on the title
   is what ships. Allowed types live in that workflow.
-- **Breaking-change changelog notes live in the PR description**, between the
-  `**▼ changelog ▼**` / `**▲ changelog ▲**` markers (uncomment the block in
-  `.github/pull_request_template.md`; `!` on the title flags it breaking). Label
-  with `**sql-insight:**` / `**sql-insight-cli:**` and write only what applies.
-  release-plz slices that range into each crate's CHANGELOG "Breaking Changes"
-  section; it can't route per crate, so both labels land in both changelogs. Keep
-  notes short — what changed plus the replacement; link rustdoc for usage.
+- **Breaking changes**: `!` on the title is the whole per-PR mechanism (#56
+  dropped the PR-description changelog block). release-plz renders each breaking
+  commit's subject as a heading in the CHANGELOG's "Breaking Changes" section,
+  credited `by @author`; migration notes, if needed, are written by hand when
+  reviewing the release PR's CHANGELOG.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,3 @@ Rules that bite if forgotten (the why is in `ARCHITECTURE.md`):
   as the commit subject, which release-plz reads to compute per-crate version
   bumps and changelogs — so `fix:` / `feat:` / `feat!:` (breaking) on the title
   is what ships. Allowed types live in that workflow.
-- **Breaking changes**: `!` on the title is the whole per-PR mechanism (#56
-  dropped the PR-description changelog block). release-plz renders each breaking
-  commit's subject as a heading in the CHANGELOG's "Breaking Changes" section,
-  credited `by @author`; migration notes, if needed, are written by hand when
-  reviewing the release PR's CHANGELOG.md.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -63,9 +63,10 @@ commit_parsers = [
 # `commit.breaking`, via `!` or a BREAKING CHANGE footer), then the normal groups
 # with breaking commits excluded and empty groups skipped — so a breaking change
 # is listed once, at the top. `striptags` honors the `<!-- N -->` sort prefixes;
-# ` by @user` credits the author. The PR link comes from the subject's `(#N)`,
-# which release-plz's default commit_preprocessor turns into a markdown link, so
-# it is not repeated here (squash merges put `(#N)` in the subject).
+# ` by @user` credits the author (on breaking headings and normal entries alike).
+# The PR link comes from the subject's `(#N)`, which release-plz's default
+# commit_preprocessor turns into a markdown link, so it is not repeated here
+# (squash merges put `(#N)` in the subject).
 #
 # Each breaking change is a `####` heading (its subject) only; migration notes,
 # if any, are written by hand when reviewing the release PR's CHANGELOG.md.
@@ -76,7 +77,7 @@ body = '''
 {% if breaking | length > 0 %}
 ### ⚠️ Breaking Changes
 {% for commit in breaking %}
-#### {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message }}
+#### {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}
 {% endfor -%}
 {% endif -%}
 {% for group, group_commits in commits | group_by(attribute="group") %}


### PR DESCRIPTION
## Summary

The changelog body template credits ` by @author` on every normal group entry
but not on the "Breaking Changes" `####` headings. This release will be the
first to render that section (#55 / #59 are `feat!`), so add the same guarded
attribution there:

```jinja
#### … {{ commit.message }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}
```

Also drops CLAUDE.md's stale breaking-changes bullet: it still described the
PR-description changelog block dropped in #56, the `!` flag is already
covered by the PR-title bullet, and the rendering / hand-written-migration-
notes facts live at their source in release-plz.toml's comments.

## Verification

`commit.remote.username` is the same variable the normal-entry line two lines
below already uses, under the same guard. Rendering can't be verified locally
without GitHub-integrated release-plz — after this merges, release-plz will
regenerate the open release PR (#48), where the Breaking Changes headings can
be eyeballed before releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
