### PR TITLE
ci: rename the security-audit workflow to cargo-deny and add its badge

### DIFF
--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,4 +1,4 @@
-name: Security Audit
+name: cargo-deny
 
 # cargo-deny runs only when the dependency set or policy changes (paths filter),
 # on pull requests and master pushes, plus a daily schedule. On PRs it runs the
@@ -11,14 +11,14 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - 'deny.toml'
-      - '.github/workflows/security-audit.yaml'
+      - '.github/workflows/cargo-deny.yaml'
   push:
     branches: [ "master" ]
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - 'deny.toml'
-      - '.github/workflows/security-audit.yaml'
+      - '.github/workflows/cargo-deny.yaml'
   schedule:
     - cron: '0 22 * * *' # daily at 22:00 UTC
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ across every SQL dialect sqlparser-rs supports.
 [![Crates.io](https://img.shields.io/crates/v/sql-insight.svg)](https://crates.io/crates/sql-insight)
 [![Docs.rs](https://docs.rs/sql-insight/badge.svg)](https://docs.rs/sql-insight)
 [![Rust](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml)
+[![Security Audit](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml)
 [![codecov](https://codecov.io/gh/takaebato/sql-insight/graph/badge.svg?token=Z1KYAWA3HY)](https://codecov.io/gh/takaebato/sql-insight)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ across every SQL dialect sqlparser-rs supports.
 [![Crates.io](https://img.shields.io/crates/v/sql-insight.svg)](https://crates.io/crates/sql-insight)
 [![Docs.rs](https://docs.rs/sql-insight/badge.svg)](https://docs.rs/sql-insight)
 [![Rust](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml)
-[![Security Audit](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml)
+[![cargo-deny](https://github.com/takaebato/sql-insight/actions/workflows/cargo-deny.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/cargo-deny.yaml)
 [![codecov](https://codecov.io/gh/takaebato/sql-insight/graph/badge.svg?token=Z1KYAWA3HY)](https://codecov.io/gh/takaebato/sql-insight)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/sql-insight-cli/README.md
+++ b/sql-insight-cli/README.md
@@ -4,6 +4,7 @@ A command-line interface to [sql-insight](https://github.com/takaebato/sql-insig
 
 [![Crates.io](https://img.shields.io/crates/v/sql-insight-cli.svg)](https://crates.io/crates/sql-insight-cli)
 [![Rust](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml)
+[![Security Audit](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml)
 [![codecov](https://codecov.io/gh/takaebato/sql-insight/graph/badge.svg?token=Z1KYAWA3HY)](https://codecov.io/gh/takaebato/sql-insight)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/sql-insight-cli/README.md
+++ b/sql-insight-cli/README.md
@@ -4,7 +4,7 @@ A command-line interface to [sql-insight](https://github.com/takaebato/sql-insig
 
 [![Crates.io](https://img.shields.io/crates/v/sql-insight-cli.svg)](https://crates.io/crates/sql-insight-cli)
 [![Rust](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/rust.yaml)
-[![Security Audit](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/security-audit.yaml)
+[![cargo-deny](https://github.com/takaebato/sql-insight/actions/workflows/cargo-deny.yaml/badge.svg?branch=master)](https://github.com/takaebato/sql-insight/actions/workflows/cargo-deny.yaml)
 [![codecov](https://codecov.io/gh/takaebato/sql-insight/graph/badge.svg?token=Z1KYAWA3HY)](https://codecov.io/gh/takaebato/sql-insight)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary

- **Rename** `security-audit.yaml` → `cargo-deny.yaml` (file + display name +
  paths self-references): the workflow checks licenses / bans / sources as
  well as advisories, so "Security Audit" both over-claims (policy checks,
  not an audit) and under-claims (licenses aren't security). For a Rust
  audience the tool's name is the precise label — same convention as
  rustfmt / clippy.
- **Add the badge** next to the Rust CI badge, in both the library README
  (symlinked to the root) and the CLI README. `?branch=master` matches the
  existing Rust badge and keeps paths-filtered PR runs from flipping it.

No required status checks reference the old names (verified: branch
protection `checks: []`), and the badge lands in the same merge as the
rename, so the URL is never stale. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)