### PR TITLE
fix: resolve an unqualified conflict-action reference as ambiguous

### DIFF
--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -552,14 +552,31 @@ impl<'a> Binder<'a> {
         };
         // A conflict-action SET always targets the insert target's own columns
         // (no other writable relations, hence the empty candidate set).
-        let bound = assignments
+        let mut bound: Vec<Assignment> = assignments
             .iter()
             .flat_map(|a| self.bind_assignment(a, &scope, target, &[]))
             .collect();
-        let predicate = selection
+        let mut predicate: Vec<Expr> = selection
             .map(|s| self.bind_expr(s, &scope))
             .into_iter()
             .collect();
+        // PostgreSQL parity: an *unqualified* reference in the conflict action
+        // is contested between the existing target row and `EXCLUDED` — PG 17 / 18
+        // reject it (`column reference "b" is ambiguous`; SQLite instead reads
+        // the target), so no single attribution is right and it surfaces
+        // `Ambiguous`, matching what the catalog-aware bind already produces
+        // (target + EXCLUDED are then two confirming witnesses). The generic
+        // scope resolution instead lets the `EXCLUDED` exposure win as the sole
+        // witness over a catalog-free (`Unknown`) target — demote exactly those
+        // bindings: in this scope an unqualified `Derived` can only be
+        // `EXCLUDED` (the sole derived relation). Qualified references
+        // (`EXCLUDED.b` / `t.b`) keep their binding.
+        for a in &mut bound {
+            demote_unqualified_excluded(&mut a.value);
+        }
+        for p in &mut predicate {
+            demote_unqualified_excluded(p);
+        }
         (bound, predicate)
     }
 
@@ -1565,6 +1582,53 @@ fn view_target_columns(projection: &[SelectItem]) -> Vec<Ident> {
         }
     }
     columns
+}
+
+/// Demote an unqualified conflict-scope reference that resolved to `EXCLUDED`
+/// (an unqualified `Binding::Derived` — `EXCLUDED` is the scope's sole derived
+/// relation) to [`Binding::Ambiguous`] — see the call in
+/// [`Binder::bind_conflict`] for the engine-verified rationale. The walk stays
+/// on the expression's **own** operands: a nested subquery owns its own scope,
+/// so its bindings are left alone. The `Expr` match is exhaustive so a new
+/// variant forces a decision here.
+fn demote_unqualified_excluded(expr: &mut Expr) {
+    match expr {
+        Expr::Column(c) => {
+            if c.qualifier.is_none() && matches!(c.binding, Binding::Derived) {
+                c.binding = Binding::Ambiguous;
+            }
+        }
+        Expr::Call { args } => args.iter_mut().for_each(demote_unqualified_excluded),
+        Expr::Case {
+            when,
+            then,
+            else_result,
+        } => {
+            when.iter_mut()
+                .chain(then.iter_mut())
+                .for_each(demote_unqualified_excluded);
+            if let Some(e) = else_result {
+                demote_unqualified_excluded(e);
+            }
+        }
+        Expr::Window {
+            arg,
+            partition,
+            order,
+        } => {
+            demote_unqualified_excluded(arg);
+            partition
+                .iter_mut()
+                .chain(order.iter_mut())
+                .for_each(demote_unqualified_excluded);
+        }
+        Expr::InSubquery { expr, .. } => demote_unqualified_excluded(expr),
+        Expr::Filter(exprs) => exprs.iter_mut().for_each(demote_unqualified_excluded),
+        // A merge fan-in can't arise (no USING join in a conflict scope) and
+        // neither can an expanded slot (no projection); a subquery's plan owns
+        // its own scope.
+        Expr::Fanin(_) | Expr::DerivedSlot { .. } | Expr::Subquery { .. } | Expr::Exists(_) => {}
+    }
 }
 
 /// The target table of a query's leading `SELECT … INTO t`, if any. `INTO`

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -656,6 +656,47 @@ mod on_conflict {
     }
 
     #[test]
+    fn pg_on_conflict_unqualified_reference_is_ambiguous() {
+        // An *unqualified* reference in the conflict action is contested
+        // between the existing target row and EXCLUDED — PostgreSQL 17 / 18
+        // reject it (`column reference "b" is ambiguous`), SQLite reads the
+        // target — so it surfaces `Ambiguous` (`table: None`), in both the
+        // SET RHS and the `DO UPDATE … WHERE` predicate. Qualify (`t.b` /
+        // `EXCLUDED.b`) to pin a side, as the neighbouring tests do.
+        assert_column_ops_with_dialect(
+            "INSERT INTO t (a, b) VALUES (1, 2) \
+             ON CONFLICT (a) DO UPDATE SET b = b + 1 WHERE b < 10",
+            &PostgreSqlDialect {},
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![ambiguous("b"), ambiguous("b")],
+                writes: vec![write("t", "a"), write("t", "b"), write("t", "b")],
+                lineage: vec![transformation(ambiguous("b"), relation("t", "b"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn pg_on_conflict_target_qualified_reference_reads_the_target() {
+        // The target-qualified counterpart of the ambiguity test: `t.b` pins
+        // the existing row, so it is a plain target read (source/sink: the
+        // sink's own data is referenced) and a self-lineage edge.
+        assert_column_ops_with_dialect(
+            "INSERT INTO t (a, b) VALUES (1, 2) \
+             ON CONFLICT (a) DO UPDATE SET b = t.b + 1",
+            &PostgreSqlDialect {},
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("t", "b")],
+                writes: vec![write("t", "a"), write("t", "b"), write("t", "b")],
+                lineage: vec![transformation(col("t", "b"), relation("t", "b"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn pg_on_conflict_do_update_set_subquery_value() {
         // DO UPDATE SET x = (SELECT max(y) FROM s): the conflict-action value is
         // a subquery — its column flows to the SET target (Transformation, via

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -678,6 +678,37 @@ mod on_conflict {
     }
 
     #[test]
+    fn pg_on_conflict_demotion_reaches_nested_operand_positions() {
+        // The demotion walk must reach every operand position an expression
+        // can nest — a window's argument / partition / order keys, an IN
+        // probe, an ANY right operand — even shapes real engines reject in a
+        // conflict action (a window function is illegal here in PG; the
+        // analyzer stays best-effort over what parses). Every unqualified `b`
+        // below is contested (target row vs EXCLUDED) and surfaces
+        // `Ambiguous`; the subquery keeps its own scope (`s.x` unaffected).
+        assert_column_ops_with_dialect(
+            "INSERT INTO t (a, b) VALUES (1, 2) ON CONFLICT (a) DO UPDATE \
+             SET b = rank() OVER (PARTITION BY b ORDER BY b) \
+             WHERE b IN (SELECT x FROM s) AND b = ANY(b)",
+            &PostgreSqlDialect {},
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![
+                    ambiguous("b"),
+                    ambiguous("b"),
+                    ambiguous("b"),
+                    read("s", "x"),
+                    ambiguous("b"),
+                    ambiguous("b"),
+                ],
+                writes: vec![write("t", "a"), write("t", "b"), write("t", "b")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn pg_on_conflict_target_qualified_reference_reads_the_target() {
         // The target-qualified counterpart of the ambiguity test: `t.b` pins
         // the existing row, so it is a plain target read (source/sink: the


### PR DESCRIPTION
## Summary

- An unqualified column in `ON CONFLICT DO UPDATE` (the SET right-hand side or the `DO UPDATE ... WHERE` predicate) is contested between the existing target row and the `EXCLUDED` pseudo-row: PostgreSQL 17 and 18 reject it (`column reference "b" is ambiguous`, verified against live instances) and SQLite reads the target, so no single attribution is right.
- The generic scope resolution instead let the `EXCLUDED` exposure win as the sole confirming witness over a catalog-free (`Unknown`) target, confidently attributing the reference to `EXCLUDED`: that matched no engine, and the answer flipped to `Ambiguous` once a catalog was supplied.
- `bind_conflict` now demotes exactly those bindings (an unqualified `Derived` in the conflict scope can only be `EXCLUDED`, the scope's sole derived relation) to `Ambiguous`, so catalog-free and catalog-aware binds agree with each other and with PostgreSQL. Such references now surface as reads / lineage sources with `table: None` and `ResolutionKind::Ambiguous`, like a multi-table UPDATE's unqualified SET. Qualified references (`EXCLUDED.b` / `t.b`) keep their binding, and nested subqueries keep their own scopes.

## Tests

- New pins: the unqualified form (SET RHS + WHERE both ambiguous) and the target-qualified counterpart (`t.b` reads the sink and self-lineages). Full workspace: 839 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)