### PR TITLE
fix: correct wildcard handling in FROM-first selects, pipe SELECT *, and ON CONFLICT lineage

### DIFF
--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -136,23 +136,86 @@ impl<'a> Binder<'a> {
             return None;
         }
         let span = options.wildcard_token.0.span;
-        let relations: Vec<&Relation> = match qualifier {
-            Some(name) => vec![self.wildcard_relation(name, scope)?],
-            None => {
-                if !scope.merge_columns.is_empty()
-                    || scope.relations.is_empty()
-                    || self.derived_names_collide(scope)
-                {
-                    return None;
-                }
-                scope.relations.iter().collect()
+        match qualifier {
+            Some(name) => {
+                let relation = self.wildcard_relation(name, scope)?;
+                self.relation_wildcard_slots(relation, scope, span)
             }
-        };
+            // A bare `*` in a **pipe output stage** (`|> SELECT *`) projects
+            // the *running outputs*, not the original FROM relations — an
+            // earlier `|> AGGREGATE` / `|> SELECT` replaced them. Query
+            // outputs are attached to the scope only at those stages (a
+            // plain projection binds against a FROM-level scope with none),
+            // so their presence is the discriminator.
+            None if !scope.query_outputs.is_empty() => self.pipe_star_slots(scope),
+            None => self.scope_star_slots(scope, |_| span),
+        }
+    }
+
+    /// A bare `*` over the scope's FROM relations: every relation's columns,
+    /// in FROM order — or `None` when any is incompletely known
+    /// (all-or-nothing). `span_of` picks the source-order anchor for each
+    /// relation's block: a written `*` anchors every block at its own token;
+    /// the implicit FROM-first form (no token) anchors each block at its
+    /// relation's written name.
+    fn scope_star_slots(
+        &self,
+        scope: &Scope,
+        span_of: impl Fn(&Relation) -> Span,
+    ) -> Option<Vec<NamedExpr>> {
+        if !scope.merge_columns.is_empty()
+            || scope.relations.is_empty()
+            || self.derived_names_collide(scope)
+        {
+            return None;
+        }
         let mut items = Vec::new();
-        for relation in relations {
-            items.extend(self.relation_wildcard_slots(relation, scope, span)?);
+        for relation in &scope.relations {
+            items.extend(self.relation_wildcard_slots(relation, scope, span_of(relation))?);
         }
         Some(items)
+    }
+
+    /// A FROM-first / projection-less SELECT (`FROM t` — DuckDB / ClickHouse
+    /// FROM-first, or a pipe base) is an **implicit** `SELECT *`: expand it
+    /// like a written bare `*`, each relation's block anchored at the
+    /// relation's own written name (there is no `*` token to anchor at).
+    /// `None` when the scope isn't completely known — the caller marks the
+    /// outputs incomplete and flags, exactly like a suppressed wildcard,
+    /// rather than presenting zero outputs as the complete set.
+    pub(super) fn expand_implicit_star(&self, scope: &Scope) -> Option<Vec<NamedExpr>> {
+        self.scope_star_slots(scope, |relation| {
+            relation
+                .exposed_name()
+                .map_or_else(Span::empty, |name| name.span)
+        })
+    }
+
+    /// A pipe-stage bare `*`: one positional slot per **running output** —
+    /// each an [`Expr::DerivedSlot`] into the pipe's input projection (inline,
+    /// so no qualifier), keeping names (anonymous outputs stay anonymous) and
+    /// adding no reads (the physical reads were counted where the outputs
+    /// were computed, exactly like a wildcard over a derived table). `None`
+    /// when the running outputs are incomplete (an unexpanded wildcard
+    /// upstream) — the slot count can't be trusted.
+    fn pipe_star_slots(&self, scope: &Scope) -> Option<Vec<NamedExpr>> {
+        if !scope.outputs_complete {
+            return None;
+        }
+        Some(
+            scope
+                .query_outputs
+                .iter()
+                .enumerate()
+                .map(|(index, output)| NamedExpr {
+                    names: OutputNames::Single(output.name.clone()),
+                    expr: Expr::DerivedSlot {
+                        qualifier: None,
+                        index,
+                    },
+                })
+                .collect(),
+        )
     }
 
     /// Whether two derived relations in scope expose the same name (illegal

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -494,8 +494,27 @@ impl<'a> Binder<'a> {
                 predicate: where_reads,
             })
         };
-        // The projection resolves against the FROM scope (base reads).
-        let (exprs, outputs_complete) = self.bind_output_items(&select.projection, &scope);
+        // The projection resolves against the FROM scope (base reads). An
+        // *empty* projection is the FROM-first / projection-less form
+        // (DuckDB / ClickHouse `FROM t`, a pipe base) — an implicit
+        // `SELECT *`: expand it like a written bare `*`, and when the scope
+        // isn't completely known, mark the outputs incomplete and flag
+        // (previously the zero-item projection passed as a *complete* empty
+        // output list, silently claiming the query projects nothing).
+        let (exprs, outputs_complete) = if select.projection.is_empty() {
+            match self.expand_implicit_star(&scope) {
+                Some(items) => (items, true),
+                None => {
+                    self.record_wildcard_suppressed(
+                        "implicit `SELECT *` (FROM-first select)",
+                        Span::empty(),
+                    );
+                    (Vec::new(), false)
+                }
+            }
+        } else {
+            self.bind_output_items(&select.projection, &scope)
+        };
         let clause_scope = scope.with_query_outputs(self.output_cols(&exprs), outputs_complete);
         // GROUP BY → an `Aggregate` over the filtered rows; its keys are reads.
         let group_by = self.group_by_keys(&select.group_by, &clause_scope);

--- a/sql-insight/src/resolver/lineage.rs
+++ b/sql-insight/src/resolver/lineage.rs
@@ -83,10 +83,13 @@ fn dml_relation_lineage<'a>(
                 relation_lineage(&i.columns, src, context, edges);
             }
             // ON CONFLICT DO UPDATE SET col = value: each `value → target.col`,
-            // an `EXCLUDED.x` ref mapped to the source's like-positioned output.
+            // an `EXCLUDED.x` ref mapped to the source's like-positioned
+            // output. The positional mapping shares the wildcard gate above:
+            // an unexpanded `*` in the source shifts positions, so an
+            // `EXCLUDED.x` must yield no edge rather than a mis-paired one.
             for a in &i.on_conflict {
                 emit_edges(
-                    conflict_value_origins(&a.value, &i.columns, src, context),
+                    conflict_value_origins(&a.value, &i.columns, src, !i.source_wildcard, context),
                     ColumnTarget::Relation(a.target.clone()),
                     edges,
                 );

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -529,11 +529,16 @@ fn trace_nth_output<'a>(
 /// to the INSERT source's like-positioned output column — a `VALUES` source
 /// maps into its cells the same way. A source with nothing to inspect at all
 /// (`DEFAULT VALUES`) yields no edge: the proposed value is untraceable,
-/// like any constant.
+/// like any constant. `positional` gates that mapping: the caller passes
+/// `false` when the source projection kept an unexpanded wildcard — its
+/// positions are then indeterminate, so an `EXCLUDED.col` yields no edge
+/// rather than a mis-paired one (the same skip the INSERT relation pairing
+/// applies).
 pub(super) fn conflict_value_origins<'a>(
     value: &'a Expr,
     columns: &[ColumnWrite],
     source: &'a LogicalPlan,
+    positional: bool,
     context: &mut TraceContext<'a>,
 ) -> Vec<(ColumnRead, ColumnLineageKind)> {
     match value {
@@ -542,6 +547,9 @@ pub(super) fn conflict_value_origins<'a>(
         // fanning out to every set-operation branch, or into a `VALUES`
         // source's like-positioned cells (its rows *are* the proposed rows).
         Expr::Column(c) if matches!(c.binding, Binding::Derived) => {
+            if !positional {
+                return Vec::new();
+            }
             let Some(i) = columns
                 .iter()
                 .position(|t| context.eq_column(&t.reference.name, &c.name))
@@ -561,23 +569,25 @@ pub(super) fn conflict_value_origins<'a>(
         Expr::Column(_) => origins_of_expr(value, source, context),
         Expr::Call { args } => transform(
             args.iter()
-                .flat_map(|e| conflict_value_origins(e, columns, source, context)),
+                .flat_map(|e| conflict_value_origins(e, columns, source, positional, context)),
         ),
         Expr::Case {
             then, else_result, ..
         } => {
             let mut sources: Vec<_> = then
                 .iter()
-                .flat_map(|e| conflict_value_origins(e, columns, source, context))
+                .flat_map(|e| conflict_value_origins(e, columns, source, positional, context))
                 .collect();
             if let Some(e) = else_result {
-                sources.extend(conflict_value_origins(e, columns, source, context));
+                sources.extend(conflict_value_origins(
+                    e, columns, source, positional, context,
+                ));
             }
             transform(sources)
         }
-        Expr::Window { arg, .. } => {
-            transform(conflict_value_origins(arg, columns, source, context))
-        }
+        Expr::Window { arg, .. } => transform(conflict_value_origins(
+            arg, columns, source, positional, context,
+        )),
         Expr::Subquery { plan, output } => {
             transform(subquery_output_origins(plan, *output, context))
         }
@@ -587,9 +597,9 @@ pub(super) fn conflict_value_origins<'a>(
             .collect(),
         // `a IN (subquery)`: the LHS flows as a value operand (see
         // `origins_of_expr`); the subquery side is a filter.
-        Expr::InSubquery { expr, .. } => {
-            transform(conflict_value_origins(expr, columns, source, context))
-        }
+        Expr::InSubquery { expr, .. } => transform(conflict_value_origins(
+            expr, columns, source, positional, context,
+        )),
         // A conflict scope holds no derived relations besides `EXCLUDED`
         // (handled as a named `Derived` ref above), so an expanded slot can't
         // occur here — trace it like any value for completeness.

--- a/sql-insight/tests/column_operation_extractor/arm_coverage.rs
+++ b/sql-insight/tests/column_operation_extractor/arm_coverage.rs
@@ -377,7 +377,10 @@ mod expr_arm_coverage {
                     transformation(col("t", "a"), out("s", 0)),
                     transformation(col("t", "b"), out("s", 0)),
                 ],
-                diagnostics: vec![],
+                // The FROM-first pipe base (`FROM t`) is an implicit
+                // `SELECT *`; catalog-free it stays unexpanded and is
+                // flagged, like any suppressed wildcard.
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
             },
         );
     }
@@ -395,7 +398,10 @@ mod expr_arm_coverage {
                 reads: vec![read("t", "a")],
                 writes: vec![],
                 lineage: vec![passthrough(col("t", "a"), out("x", 0))],
-                diagnostics: vec![],
+                // The FROM-first pipe base (`FROM t`) is an implicit
+                // `SELECT *`; catalog-free it stays unexpanded and is
+                // flagged, like any suppressed wildcard.
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
             },
         );
     }

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -672,6 +672,27 @@ mod on_conflict {
     }
 
     #[test]
+    fn pg_on_conflict_excluded_mapping_is_gated_by_an_unexpanded_wildcard() {
+        // The source projection kept an unexpanded `*`, so its positions are
+        // indeterminate — the `EXCLUDED.a` positional mapping must yield no
+        // edge (previously it mapped target position 0 onto the shifted
+        // source outputs and fabricated `s.y -> t2.b`), matching the skip
+        // the INSERT relation pairing already applies.
+        assert_column_ops_with_dialect(
+            "INSERT INTO t2 (a, b) SELECT *, y FROM s \
+             ON CONFLICT (a) DO UPDATE SET b = EXCLUDED.a",
+            &PostgreSqlDialect {},
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s", "y")],
+                writes: vec![write("t2", "a"), write("t2", "b"), write("t2", "b")],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
     fn pg_on_conflict_demotion_reaches_nested_operand_positions() {
         // The demotion walk must reach every operand position an expression
         // can nest — a window's argument / partition / order keys, an IN

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -693,6 +693,37 @@ mod on_conflict {
     }
 
     #[test]
+    fn pg_on_conflict_excluded_maps_through_an_expanded_wildcard_source() {
+        // The positive counterpart of the gate: with a catalog the source's
+        // `*` expands, positions are determinate, and `EXCLUDED.a` correctly
+        // maps to the expanded slot 0 (`s.x`) — the gate only fires for an
+        // *unexpanded* wildcard.
+        use sql_insight::catalog::{Catalog, CatalogTable};
+        let catalog = Catalog::new().table(CatalogTable::new("public", "s").columns(["x", "y"]));
+        let options = ExtractorOptions::new().with_catalog(&catalog);
+        let actual = extract_column_operations_with_options(
+            &PostgreSqlDialect {},
+            "INSERT INTO t2 (a, b) SELECT * FROM s \
+             ON CONFLICT (a) DO UPDATE SET b = EXCLUDED.a",
+            options,
+        )
+        .unwrap()
+        .remove(0)
+        .unwrap();
+        let conflict_edges: Vec<String> = actual
+            .lineage
+            .iter()
+            .filter(
+                |e| matches!(&e.target, ColumnTarget::Relation(w) if w.reference.name.value == "b"),
+            )
+            .map(|e| e.source.reference.name.value.clone())
+            .collect();
+        // b receives the INSERT pairing (s.y) and the conflict SET (s.x).
+        assert_eq!(conflict_edges, vec!["y", "x"]);
+        assert!(actual.diagnostics.is_empty(), "{:?}", actual.diagnostics);
+    }
+
+    #[test]
     fn pg_on_conflict_demotion_reaches_nested_operand_positions() {
         // The demotion walk must reach every operand position an expression
         // can nest — a window's argument / partition / order keys, an IN

--- a/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
+++ b/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
@@ -1166,3 +1166,139 @@ mod guards {
         );
     }
 }
+
+mod implicit_star {
+    //! A FROM-first / projection-less SELECT (DuckDB / ClickHouse `FROM t`,
+    //! a pipe base) is an implicit `SELECT *` — expanded by the same
+    //! machinery, or flagged when the scope isn't fully known. Previously
+    //! the empty projection passed as a *complete* zero-column output,
+    //! silently claiming the query projects nothing.
+    use super::*;
+
+    #[test]
+    fn from_first_select_expands_like_a_bare_wildcard() {
+        let catalog = TestCatalog::default().with("t", vec!["a", "b"]);
+        assert_column_ops_with_catalog(
+            "FROM t",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![expanded_read("t", "a"), expanded_read("t", "b")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(expanded_read("t", "a"), expanded_out("a", 0)),
+                    passthrough(expanded_read("t", "b"), expanded_out("b", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn ctas_over_a_from_first_select_pairs_the_expanded_columns() {
+        // `CREATE TABLE u AS FROM t` used to bind a complete zero-column
+        // projection: no column writes, no lineage, no diagnostic. Expanded,
+        // it pairs like `CREATE TABLE u AS SELECT * FROM t`.
+        let catalog = TestCatalog::default().with("t", vec!["a", "b"]);
+        let quoted_write = |col: &str| ColumnWrite {
+            reference: ColumnReference {
+                table: Some(table("u")),
+                name: qident(col),
+            },
+            resolution: ResolutionKind::Inferred,
+        };
+        assert_column_ops_with_catalog(
+            "CREATE TABLE u AS FROM t",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::CreateTable,
+                reads: vec![expanded_read("t", "a"), expanded_read("t", "b")],
+                writes: vec![quoted_write("a"), quoted_write("b")],
+                lineage: vec![
+                    passthrough(
+                        expanded_read("t", "a"),
+                        ColumnTarget::Relation(quoted_write("a")),
+                    ),
+                    passthrough(
+                        expanded_read("t", "b"),
+                        ColumnTarget::Relation(quoted_write("b")),
+                    ),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn unexpandable_from_first_select_is_flagged_not_silently_empty() {
+        // Catalog-free the implicit `*` can't be enumerated: the outputs are
+        // incomplete and flagged — a downstream CTAS drops its column pairing
+        // (`source_wildcard`) instead of writing zero columns silently.
+        assert_column_ops(
+            "CREATE TABLE u AS FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::CreateTable,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn pipe_select_star_projects_the_running_outputs() {
+        // `|> SELECT *` covers the *running* pipe outputs, not the original
+        // FROM relations: after `|> AGGREGATE SUM(a) AS s GROUP BY b` the
+        // output is (s, b), so the star's slots trace to the aggregate's
+        // expressions (t.a transformed into s) — previously it re-expanded
+        // the base table and fabricated passthrough edges for every column
+        // of `t`.
+        let catalog = TestCatalog::default().with("t", vec!["a", "b"]);
+        assert_column_ops_with_catalog(
+            "FROM t |> AGGREGATE SUM(a) AS s GROUP BY b |> SELECT *",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    expanded_read("t", "a"),
+                    expanded_read("t", "b"),
+                    read_with_ref(cataloged_table("t"), "a", ResolutionKind::Cataloged),
+                    read_with_ref(cataloged_table("t"), "b", ResolutionKind::Cataloged),
+                ],
+                writes: vec![],
+                lineage: vec![
+                    transformation(
+                        read_with_ref(cataloged_table("t"), "a", ResolutionKind::Cataloged),
+                        out("s", 0),
+                    ),
+                    passthrough(
+                        read_with_ref(cataloged_table("t"), "b", ResolutionKind::Cataloged),
+                        out("b", 1),
+                    ),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn pipe_select_star_over_incomplete_outputs_stays_suppressed() {
+        // Catalog-free the base implicit `*` is unexpanded, so the running
+        // outputs are incomplete — the pipe star must not pretend to know
+        // the slot count (two flags: the base and the pipe star).
+        assert_column_ops(
+            "FROM t |> SELECT *",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![
+                    diag(ColumnLevelDiagnosticKind::WildcardSuppressed),
+                    diag(ColumnLevelDiagnosticKind::WildcardSuppressed),
+                ],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
+++ b/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
@@ -1283,6 +1283,62 @@ mod implicit_star {
     }
 
     #[test]
+    fn outer_wildcard_expands_through_a_from_first_derived_body() {
+        // The derived body's implicit `*` expands (catalog), completing the
+        // slot view — so the outer `*` expands through it. Previously the
+        // body bound as a *complete empty* output and the outer star
+        // "expanded" to zero columns with no diagnostic.
+        let catalog = TestCatalog::default().with("t", vec!["a", "b"]);
+        assert_column_ops_with_catalog(
+            "SELECT * FROM (FROM t) v",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![expanded_read("t", "a"), expanded_read("t", "b")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(expanded_read("t", "a"), expanded_out("a", 0)),
+                    passthrough(expanded_read("t", "b"), expanded_out("b", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn pipe_select_star_over_a_set_operation_body() {
+        // Over a set-operation body the running outputs are the union's
+        // result columns; the star's slots fan across both branches
+        // positionally.
+        let catalog = TestCatalog::default()
+            .with("t", vec!["a", "b"])
+            .with("s", vec!["x", "y"]);
+        assert_column_ops_with_catalog(
+            "SELECT a FROM t UNION ALL SELECT x FROM s |> SELECT *",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read_with_ref(cataloged_table("t"), "a", ResolutionKind::Cataloged),
+                    read_with_ref(cataloged_table("s"), "x", ResolutionKind::Cataloged),
+                ],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(
+                        read_with_ref(cataloged_table("t"), "a", ResolutionKind::Cataloged),
+                        out("a", 0),
+                    ),
+                    passthrough(
+                        read_with_ref(cataloged_table("s"), "x", ResolutionKind::Cataloged),
+                        out("a", 0),
+                    ),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn pipe_select_star_over_incomplete_outputs_stays_suppressed() {
         // Catalog-free the base implicit `*` is unexpanded, so the running
         // outputs are incomplete — the pipe star must not pretend to know


### PR DESCRIPTION
## Summary

Three bugs in the wildcard-expansion machinery, each presenting indeterminate column positions as determinate ones.

- **A FROM-first / projection-less SELECT bound as a complete empty output.** DuckDB / ClickHouse `FROM t` and pipe bases parse with an empty projection, which the binder reported as a *complete* zero-column output: `CREATE TABLE u AS FROM t` produced no column writes, no lineage, and no diagnostic, and an outer wildcard over such a body "expanded" to zero columns silently. The form is an implicit `SELECT *` and now goes through the expansion machinery: with a known scope it expands (each relation's block anchored at the relation's written name, since there is no `*` token), otherwise the outputs are marked incomplete and `WildcardSuppressed` is raised, exactly like a written wildcard.
- **A pipe-stage bare `*` expanded the wrong relations.** `FROM t |> AGGREGATE SUM(a) AS s GROUP BY b |> SELECT *` re-expanded the original FROM relation, fabricating cataloged reads and passthrough edges for every column of `t` when the running output is `(s, b)`. A bare `*` in a pipe output stage (detected by the scope carrying query outputs, which a plain projection bind never does) now projects one positional slot per running output as a `DerivedSlot` into the pipe's input projection: names are kept (anonymous outputs stay anonymous), no reads are added (the physical reads were counted where the outputs were computed), and incomplete running outputs keep the star suppressed.
- **ON CONFLICT lineage was not gated by `source_wildcard`.** With an unexpanded `*` in the INSERT source projection, the `EXCLUDED.col` positional mapping hit the shifted source outputs and fabricated cross-column edges (`s.y -> t2.b` for `SET b = EXCLUDED.a`). `conflict_value_origins` now takes a positional flag and yields no edge for `EXCLUDED` references when the source kept an unexpanded wildcard, matching the skip the INSERT relation pairing already applies. Non-`EXCLUDED` conflict references keep their edges, and an *expanded* wildcard source still maps `EXCLUDED` correctly.

## Tests

- New pins: FROM-first expansion (bare query, CTAS pairing, transitive derived body, catalog and catalog-free), pipe `SELECT *` over running outputs / a set-operation body / incomplete outputs, and the conflict gate in both directions (unexpanded suppresses, expanded maps). Two existing pipe pins gain the (intended) implicit-star diagnostic. Full workspace: 857 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)