### PR TITLE
fix: close resolution and trace gaps across CTE, APPLY, USING, and derived tables

### DIFF
--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -140,21 +140,33 @@ impl<'a> Binder<'a> {
     }
 
     /// Bind `f` with `relations` pushed as an enclosing correlation level (a
-    /// subquery in an expression / a LATERAL derived table).
-    fn in_outer<R>(&mut self, relations: Vec<Relation>, f: impl FnOnce(&mut Self) -> R) -> R {
-        let child = self.context.with_outer(relations);
+    /// subquery in an expression / a LATERAL derived table). `merge_columns`
+    /// carries the level's `USING` / NATURAL merge names, so a correlated
+    /// reference to one fans in like it would in the enclosing query (pass
+    /// empty when the caller has only bare relations in hand).
+    fn in_outer<R>(
+        &mut self,
+        relations: Vec<Relation>,
+        merge_columns: Vec<Ident>,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let child = self.context.with_outer(relations, merge_columns);
         self.in_scope(child, f)
     }
 
-    /// Bind `f` (a lambda body) with `relations` as an enclosing level and the
-    /// lambda `params` as a `Lambda` level on top.
+    /// Bind `f` (a lambda body) with `relations` (+ their merge columns) as an
+    /// enclosing level and the lambda `params` as a `Lambda` level on top.
     fn in_lambda<R>(
         &mut self,
         relations: Vec<Relation>,
+        merge_columns: Vec<Ident>,
         params: impl IntoIterator<Item = Ident>,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        let child = self.context.with_outer(relations).with_lambda(params);
+        let child = self
+            .context
+            .with_outer(relations, merge_columns)
+            .with_lambda(params);
         self.in_scope(child, f)
     }
 

--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -814,6 +814,14 @@ fn join_is_natural(op: &JoinOperator) -> bool {
     matches!(join_constraint(op), Some(JoinConstraint::Natural))
 }
 
+/// Whether a join operator is a T-SQL `CROSS APPLY` / `OUTER APPLY` — lateral
+/// by construction (the right side is evaluated per left row and references
+/// its columns), though sqlparser parses the applied factor with
+/// `lateral: false`.
+fn is_apply(op: &JoinOperator) -> bool {
+    matches!(op, JoinOperator::CrossApply | JoinOperator::OuterApply)
+}
+
 /// Whether a join operator is a ClickHouse `ARRAY JOIN` / `LEFT ARRAY JOIN` /
 /// `INNER ARRAY JOIN` — which unnests an array expression inline rather than
 /// joining a relation, so its operand is a column expression, not a scanned

--- a/sql-insight/src/resolver/binder/context.rs
+++ b/sql-insight/src/resolver/binder/context.rs
@@ -18,8 +18,13 @@ use super::*;
 #[derive(Clone)]
 pub(super) enum Level {
     /// An enclosing query level's FROM relations (a subquery / the query the
-    /// current one is correlated into).
-    Relations(Vec<Relation>),
+    /// current one is correlated into), with the level's `USING` / NATURAL
+    /// merge columns — a correlated reference to one fans in to its owners
+    /// exactly as it would in the enclosing query itself.
+    Relations {
+        relations: Vec<Relation>,
+        merge_columns: Vec<Ident>,
+    },
     /// A lambda's parameters (`x` in `x -> …`): a bare reference resolves to
     /// [`Binding::Local`] — not a table column.
     Lambda(Vec<Ident>),
@@ -54,8 +59,15 @@ impl Context {
 
     /// A child context with one more enclosing relation level on the stack (used
     /// when descending into a subquery in an expression / a LATERAL factor).
-    pub(super) fn with_outer(&self, relations: Vec<Relation>) -> Context {
-        self.pushing(Level::Relations(relations))
+    pub(super) fn with_outer(
+        &self,
+        relations: Vec<Relation>,
+        merge_columns: Vec<Ident>,
+    ) -> Context {
+        self.pushing(Level::Relations {
+            relations,
+            merge_columns,
+        })
     }
 
     /// A child context with the lambda `params` pushed as a level (used to bind

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -565,6 +565,7 @@ impl<'a> Binder<'a> {
             // resolves its own columns first, the enclosing query last.
             SqlExpr::Lambda(lambda) => self.in_lambda(
                 scope.relations.clone(),
+                scope.merge_columns.clone(),
                 // A lambda param is now a `LambdaFunctionParameter` (name +
                 // optional type); the binder only tracks the bound name.
                 lambda.params.iter().map(|p| p.name.clone()),
@@ -617,8 +618,40 @@ impl<'a> Binder<'a> {
     /// (`Expr::Fanin`); everything else is a single `Expr::Column`.
     pub(super) fn resolve_expr(&self, parts: &[Ident], scope: &Scope) -> Expr {
         if parts.len() == 1 {
-            if let Some(fanin) = self.merge_fanin(&parts[0], scope) {
+            let name = &parts[0];
+            if let Some(fanin) = self.merge_fanin(name, scope) {
                 return fanin;
+            }
+            // A name the current scope can't own falls through the enclosing
+            // stack (correlation) — mirroring `resolve`'s walk — and a merge
+            // column there fans in exactly as it would in that query itself.
+            // The first level to claim the name stops the walk either way (a
+            // level that owns it singly resolves below; a lambda parameter
+            // shadows it as a `Local`).
+            if self.resolve_in(parts, &scope.relations).is_none() {
+                for level in self.context.outer.iter().rev() {
+                    match level {
+                        Level::Relations {
+                            relations,
+                            merge_columns,
+                        } => {
+                            if let Some(fanin) = self.fanin_in(name, relations, merge_columns) {
+                                return fanin;
+                            }
+                            if self.resolve_in(parts, relations).is_some() {
+                                break;
+                            }
+                        }
+                        Level::Lambda(params) => {
+                            if params
+                                .iter()
+                                .any(|p| self.eq(self.style.casing.column, p, name))
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
         Expr::Column(Box::new(self.resolve(parts, scope)))
@@ -630,15 +663,24 @@ impl<'a> Binder<'a> {
     /// relations that declare the column (`Cataloged`), catalog-free reaches
     /// every joined relation (`Inferred`).
     pub(super) fn merge_fanin(&self, name: &Ident, scope: &Scope) -> Option<Expr> {
-        if !scope
-            .merge_columns
+        self.fanin_in(name, &scope.relations, &scope.merge_columns)
+    }
+
+    /// [`merge_fanin`](Self::merge_fanin) over one resolution frame's raw
+    /// parts — the current [`Scope`] or an enclosing [`Level::Relations`].
+    fn fanin_in(
+        &self,
+        name: &Ident,
+        relations: &[Relation],
+        merge_columns: &[Ident],
+    ) -> Option<Expr> {
+        if !merge_columns
             .iter()
             .any(|m| self.eq(self.style.casing.column, m, name))
         {
             return None;
         }
-        let refs: Vec<BoundColumn> = scope
-            .relations
+        let refs: Vec<BoundColumn> = relations
             .iter()
             .filter_map(|rel| self.fanin_owner(rel, name))
             .collect();
@@ -843,8 +885,10 @@ impl<'a> Binder<'a> {
     /// its own FROM plus the containing scope's relations (pushed onto the
     /// correlation stack), so a correlated reference reaches outward.
     pub(super) fn bind_subquery(&mut self, query: &Query, scope: &Scope) -> LogicalPlan {
-        self.in_outer(scope.relations.clone(), |b| b.bind_query(query))
-            .0
+        self.in_outer(scope.relations.clone(), scope.merge_columns.clone(), |b| {
+            b.bind_query(query)
+        })
+        .0
     }
 
     pub(super) fn bind_function_args(&mut self, function: &Function, scope: &Scope) -> Vec<Expr> {

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -599,6 +599,15 @@ impl<'a> Binder<'a> {
             // relations so it reads a column, not a table.
             let (right, right_scope) = if is_array_join(&j.join_operator) {
                 self.bind_array_join(&j.relation, &visible)
+            } else if is_apply(&j.join_operator) {
+                // A T-SQL `CROSS / OUTER APPLY` factor is lateral by
+                // construction, but sqlparser parses it with `lateral: false`
+                // — so push the visible relations as an enclosing level for
+                // the whole factor (a derived body and a table function's
+                // arguments both correlate to the left rows).
+                self.in_outer(visible.clone(), |b| {
+                    b.bind_table_factor(&j.relation, &visible)
+                })
             } else {
                 self.bind_table_factor(&j.relation, &visible)
             };

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -605,7 +605,7 @@ impl<'a> Binder<'a> {
                 // — so push the visible relations as an enclosing level for
                 // the whole factor (a derived body and a table function's
                 // arguments both correlate to the left rows).
-                self.in_outer(visible.clone(), |b| {
+                self.in_outer(visible.clone(), scope.merge_columns.clone(), |b| {
                     b.bind_table_factor(&j.relation, &visible)
                 })
             } else {
@@ -833,7 +833,11 @@ impl<'a> Binder<'a> {
                 ..
             } => {
                 let (mut op, sub_scope) = if *lateral {
-                    self.in_outer(left.to_vec(), |b| b.bind_query(subquery))
+                    // Only the sibling relations are in hand here (the
+                    // enclosing scope's merge columns don't thread through
+                    // `bind_table_factor`), so a LATERAL body sees them
+                    // without any fan-in — a pre-existing limit.
+                    self.in_outer(left.to_vec(), Vec::new(), |b| b.bind_query(subquery))
                 } else {
                     self.bind_query(subquery)
                 };

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -389,9 +389,14 @@ impl<'a> Binder<'a> {
             SetExpr::Query(query) => self.bind_query(query),
             SetExpr::Values(values) => self.bind_values(values),
             // `TABLE foo`: a whole-table query body (e.g. the source of
-            // `CREATE TABLE t AS TABLE foo`). Bind it as a read scan.
+            // `CREATE TABLE t AS TABLE foo`). A bare name checks the CTE
+            // environment first, like a FROM factor (`WITH c AS (…) TABLE c`
+            // reads the CTE, not a phantom table `c`); else a read scan.
             SetExpr::Table(table) => match table_set_expr_ref(table) {
-                Some(written) => self.bind_named_table(&written, None),
+                Some(written) => match self.bind_cte_by_name(&written, None) {
+                    Some(bound) => bound,
+                    None => self.bind_named_table(&written, None),
+                },
                 None => (LogicalPlan::Empty, Scope::default()),
             },
             // `WITH … INSERT/UPDATE/DELETE/MERGE …`: the DML statement is the
@@ -747,6 +752,38 @@ impl<'a> Binder<'a> {
         (scan, Scope::single(relation))
     }
 
+    /// A bare name matching an in-scope CTE resolves to a `CteRef` (the body
+    /// lives once on the owning `With`) exposing the CTE's output columns as
+    /// a synthetic relation — so the CTE name never surfaces as a table read.
+    /// `None` when the name is qualified or matches no CTE (a base table).
+    /// Shared by the table factor and a `TABLE foo` query body.
+    fn bind_cte_by_name(
+        &mut self,
+        written: &TableReference,
+        alias_name: Option<Ident>,
+    ) -> Option<(LogicalPlan, Scope)> {
+        if written.schema.is_some() || written.catalog.is_some() {
+            return None;
+        }
+        let cte = self
+            .context
+            .ctes
+            .iter()
+            .rev()
+            .find(|c| self.eq(self.style.casing.table_alias, &c.name, &written.name))?;
+        let relation = Relation::Derived {
+            alias: alias_name.clone().or_else(|| Some(cte.name.clone())),
+            columns: cte.columns.clone(),
+        };
+        Some((
+            LogicalPlan::CteRef(CteRef {
+                name: cte.name.clone(),
+                alias: alias_name,
+            }),
+            Scope::single(relation),
+        ))
+    }
+
     pub(super) fn bind_table_factor(
         &mut self,
         factor: &TableFactor,
@@ -771,27 +808,8 @@ impl<'a> Binder<'a> {
                     return (LogicalPlan::Empty, Scope::default());
                 };
                 let alias_name = alias.as_ref().map(|a| a.name.clone());
-                // A bare name matching an in-scope CTE resolves to a `CteRef`
-                // (the body lives once on the owning `With`) exposing the CTE's
-                // output columns as a synthetic relation.
-                if written.schema.is_none() && written.catalog.is_none() {
-                    if let Some(cte) =
-                        self.context.ctes.iter().rev().find(|c| {
-                            self.eq(self.style.casing.table_alias, &c.name, &written.name)
-                        })
-                    {
-                        let relation = Relation::Derived {
-                            alias: alias_name.clone().or_else(|| Some(cte.name.clone())),
-                            columns: cte.columns.clone(),
-                        };
-                        return (
-                            LogicalPlan::CteRef(CteRef {
-                                name: cte.name.clone(),
-                                alias: alias_name,
-                            }),
-                            Scope::single(relation),
-                        );
-                    }
+                if let Some(bound) = self.bind_cte_by_name(&written, alias_name.clone()) {
+                    return bound;
                 }
                 self.bind_named_table(&written, alias_name)
             }

--- a/sql-insight/src/resolver/binder/resolve.rs
+++ b/sql-insight/src/resolver/binder/resolve.rs
@@ -53,7 +53,7 @@ impl<'a> Binder<'a> {
                     .iter()
                     .rev()
                     .find_map(|level| match level {
-                        Level::Relations(relations) => self.resolve_in(parts, relations),
+                        Level::Relations { relations, .. } => self.resolve_in(parts, relations),
                         Level::Lambda(params) => (parts.len() == 1
                             && params
                                 .iter()
@@ -73,7 +73,7 @@ impl<'a> Binder<'a> {
     /// could own the column (so the caller falls through to an enclosing
     /// scope) and `Some(binding)` once at least one is a candidate (even if
     /// that collapses to `Ambiguous` — a name owned here doesn't escape).
-    fn resolve_in(&self, parts: &[Ident], relations: &[Relation]) -> Option<Binding> {
+    pub(super) fn resolve_in(&self, parts: &[Ident], relations: &[Relation]) -> Option<Binding> {
         let name = parts.last()?;
         let candidates: Vec<Binding> = if parts.len() == 1 {
             relations

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -366,6 +366,16 @@ fn origins_into<'a>(
 ) -> Vec<(ColumnRead, ColumnLineageKind)> {
     match op {
         LogicalPlan::Projection(p) => {
+            // An inline producer is an *unaliased* derived table (no relation
+            // boundary to match a qualifier against), so a qualified
+            // reference never claims it by name — its producer sits behind a
+            // `SubqueryAlias` / `CteRef` boundary (the slot trace has the
+            // same guard). Without this, `x.a` over `(SELECT a FROM s),
+            // (SELECT a FROM u) AS x` also traced into the unaliased `s`
+            // producer.
+            if qualifier.is_some() {
+                return Vec::new();
+            }
             // Resolve by name to a position, then through any multi-alias
             // back-reference — `d.v` over `explode(arr) AS (k, v)` traces the
             // head expression, reaching `arr`.
@@ -427,6 +437,11 @@ fn origins_into<'a>(
         // `conflict_value_origins`, and `output_operands` flattens nested
         // set-ops so an N-way `A UNION B UNION C` traces all branches at once.
         LogicalPlan::SetOp(_) => {
+            // Inline like the `Projection` arm above: a qualified reference
+            // never claims an unaliased set-operation producer by name.
+            if qualifier.is_some() {
+                return Vec::new();
+            }
             let operands = output_operands(op);
             let Some(i) = operands.first().and_then(|o| {
                 output_slots(o.outputs)

--- a/sql-insight/tests/column_operation_extractor/joins_sets.rs
+++ b/sql-insight/tests/column_operation_extractor/joins_sets.rs
@@ -474,6 +474,45 @@ mod join_using_and_natural {
     }
 
     #[test]
+    fn correlated_subquery_reference_fans_in_the_outer_merge_column() {
+        // A correlated reference to the outer query's USING merge column
+        // fans in exactly as it would in the outer query itself — the
+        // correlation level carries the merge columns, not just the
+        // relations (it used to fall `Ambiguous`).
+        assert_column_ops(
+            "SELECT (SELECT k) FROM a JOIN b USING (k)",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("a", "k"), read("b", "k")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("a", "k"), out_anon(0)),
+                    transformation(col("b", "k"), out_anon(0)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn inner_scope_claims_the_name_before_the_outer_merge_column() {
+        // An inner relation that could own the name wins over the outer
+        // merge column (innermost-first, like all correlation): `k` inside
+        // the EXISTS pins its sole inner suspect `c`, no outer fan-in.
+        assert_column_ops(
+            "SELECT a.id FROM a JOIN b USING (k) \
+             WHERE EXISTS (SELECT 1 FROM c WHERE c.x = k)",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("a", "id"), read("c", "x"), read("c", "k")],
+                writes: vec![],
+                lineage: vec![passthrough(col("a", "id"), out("id", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn join_using_id_fans_in_at_each_occurrence() {
         // The merge column fans in independently per occurrence: the
         // projection `id` and the WHERE `id` each expand to t1.id +

--- a/sql-insight/tests/column_operation_extractor/joins_sets.rs
+++ b/sql-insight/tests/column_operation_extractor/joins_sets.rs
@@ -660,6 +660,7 @@ mod join_using_and_natural {
 
 mod lateral_and_correlation {
     use super::*;
+    use sql_insight::sqlparser::dialect::MsSqlDialect;
 
     #[test]
     fn lateral_subquery_resolves_inner_ref_to_inner_table() {
@@ -717,6 +718,43 @@ mod lateral_and_correlation {
                     transformation(unresolved("a"), out("x", 0)),
                     transformation(col("t2", "b"), out("x", 0)),
                 ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn cross_apply_derived_body_sees_the_left_side() {
+        // T-SQL `CROSS APPLY` is lateral by construction (sqlparser parses
+        // the factor with `lateral: false`, so the binder grants the
+        // visibility off the join operator): the applied body's `t.b`
+        // resolves to the left relation — it used to fall `Unresolved`.
+        assert_column_ops_with_dialect(
+            &MsSqlDialect {},
+            "SELECT v.b FROM t CROSS APPLY (SELECT t.b AS b) v",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "b")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "b"), out("b", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn outer_apply_function_arguments_see_the_left_side() {
+        // The other APPLY shape: a table-valued function whose arguments
+        // reference the left rows. The argument read resolves and feeds the
+        // function's output at function granularity (a Transformation).
+        assert_column_ops_with_dialect(
+            &MsSqlDialect {},
+            "SELECT v.x FROM t OUTER APPLY dbo.split(t.csv) v",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "csv")],
+                writes: vec![],
+                lineage: vec![transformation(col("t", "csv"), out("x", 0))],
                 diagnostics: vec![],
             },
         );

--- a/sql-insight/tests/column_operation_extractor/lineage.rs
+++ b/sql-insight/tests/column_operation_extractor/lineage.rs
@@ -658,6 +658,53 @@ mod collapse {
     }
 
     #[test]
+    fn qualified_ref_does_not_trace_into_an_unaliased_sibling_derived() {
+        // `x.a` names the aliased derived table only; the *unaliased*
+        // sibling producer — which exposes an `a` too — has no relation
+        // boundary a qualifier could match, so the named trace must not
+        // claim it (it used to, fabricating `s.a -> a`). Its scan still
+        // reads (reads are syntactic); only the lineage is pinned to `u`.
+        assert_column_ops(
+            "SELECT x.a FROM (SELECT a FROM s), (SELECT a FROM u) AS x",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("s", "a"), read("u", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("u", "a"), out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+        // The set-operation producer is inline the same way — same guard.
+        assert_column_ops(
+            "SELECT x.a FROM (SELECT a FROM s UNION SELECT a FROM s2), \
+             (SELECT a FROM u) AS x",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("s", "a"), read("s2", "a"), read("u", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("u", "a"), out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn unqualified_ref_still_traces_into_an_unaliased_derived() {
+        // Without a qualifier the inline producer is legitimately claimed
+        // (an unaliased derived is addressable only unqualified).
+        assert_column_ops(
+            "SELECT a FROM (SELECT a FROM s)",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("s", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("s", "a"), out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn cte_referenced_twice_collapses_each_use() {
         // Each cte reference in the projection collapses independently
         // back to t1.id.

--- a/sql-insight/tests/column_operation_extractor/resolution.rs
+++ b/sql-insight/tests/column_operation_extractor/resolution.rs
@@ -315,6 +315,36 @@ mod catalog_strict {
     }
 
     #[test]
+    fn correlated_reference_falls_through_to_the_outer_merge_column() {
+        // The catalog rules the inner relation out (`c` doesn't list `k`),
+        // so the correlated reference falls through to the enclosing level
+        // and fans in to the outer USING owners — catalog-free the sole
+        // inner suspect `c` would pin it instead (the catalog-free pin is
+        // in `joins_sets`).
+        let catalog = TestCatalog::default()
+            .with("a", vec!["id", "k"])
+            .with("b", vec!["k", "y"])
+            .with("c", vec!["x"]);
+        assert_column_ops_with_catalog(
+            "SELECT a.id FROM a JOIN b USING (k) \
+             WHERE EXISTS (SELECT 1 FROM c WHERE c.x = k)",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read_confirmed("a", "id"),
+                    read_confirmed("c", "x"),
+                    read_confirmed("a", "k"),
+                    read_confirmed("b", "k"),
+                ],
+                writes: vec![],
+                lineage: vec![passthrough(col_confirmed("a", "id"), out("id", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn multi_table_update_natural_join_fans_in_the_schema_common_column() {
         // A NATURAL join in the UPDATE target clause takes its merge columns
         // from the catalog's schema-common columns (`id`), so the

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -208,6 +208,44 @@ mod select {
     }
 
     #[test]
+    fn table_body_resolves_a_cte_not_a_phantom_table() {
+        // `TABLE c` is sugar for `SELECT * FROM c`, so a bare name checks
+        // the CTE environment like a FROM factor — the CTE binding `c`
+        // never surfaces as a table read. A qualified `TABLE public.c`
+        // names a real table as usual (the sibling assertion).
+        assert_ops(
+            "WITH c AS (SELECT a FROM t) TABLE c",
+            TableOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t")],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+        assert_ops(
+            "WITH c AS (SELECT a FROM t) TABLE public.c",
+            TableOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    TableRead {
+                        reference: TableReference {
+                            catalog: None,
+                            schema: Some("public".into()),
+                            name: "c".into(),
+                        },
+                        resolution: ResolutionKind::Inferred,
+                    },
+                    read("t"),
+                ],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn bare_values_emits_nothing() {
         // `VALUES (1, 2)` parses as a query whose body is a VALUES
         // clause — no table references, no writes, no lineage.


### PR DESCRIPTION
## Summary

Four resolution / trace bugs, each verified against the live CLI before and after. Three make the binder fabricate or drop references; one makes the lineage trace claim the wrong producer.

- **A bare `TABLE c` body ignored the CTE environment.** `WITH c AS (SELECT a FROM t) TABLE c` surfaced a phantom table read `c` (with a catalog it could even come back `Cataloged`), breaking the invariant that a CTE binding never surfaces as a table read — `SetExpr::Table` went straight to the named-table scan, skipping the CTE lookup every FROM factor gets. The lookup is now a shared helper consulted by both sites, so the body binds to a `CteRef` exactly like `SELECT * FROM c` would; a qualified `TABLE public.c` still names a real table.
- **`CROSS / OUTER APPLY` had no lateral visibility.** sqlparser parses an APPLY's applied factor with `lateral: false`, so every correlated reference fell `Unresolved` — though APPLY is lateral by construction. The join loop now pushes the visible relations as an enclosing correlation level when the operator is an APPLY, covering both shapes: a derived body's references (`t CROSS APPLY (SELECT t.b) v`) and a table-valued function's arguments (`t OUTER APPLY dbo.split(t.csv) v`).
- **A correlated reference to an outer `USING` merge column lost its fan-in.** The correlation stack carried only the enclosing level's relations, so `SELECT (SELECT k) FROM a JOIN b USING (k)` fell `Ambiguous` instead of fanning in to `a.k` / `b.k` as the same reference does in the outer query. A correlation level now carries the level's merge columns, and resolution walks the enclosing stack innermost-first when the current scope can't own the name — an inner relation that could own it still wins (catalog knowledge that rules the inner relation out re-enables the outer fan-in), and a lambda parameter still shadows.
- **A qualified trace claimed an unaliased sibling derived table by name.** `SELECT x.a FROM (SELECT a FROM s), (SELECT a FROM u) AS x` fabricated a `s.a → a` lineage edge beside the real `u.a → a`: the named origin trace's inline `Projection` / `SetOp` arms ignored the qualifier, though the positional (slot) trace already guarded them. The named trace now mirrors that guard — an inline producer has no relation boundary a qualifier could match, so only unqualified references claim it. (The scan's reads are untouched: reads are syntactic.)

## Tests

New pins for each: the `TABLE` body against a CTE (bare and qualified), the APPLY derived-body and function-argument correlations, the correlated merge-column fan-in (catalog-free inner-suspect pin, inner-scope precedence, and the cataloged fall-through), and the qualified-trace guard (Projection and SetOp inline producers, plus the unqualified case that must keep tracing). Full workspace: 882 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
