### PR TITLE
fix: make pipe operators evolve the running scope correctly

### DIFF
--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -570,6 +570,25 @@ fn join(left: LogicalPlan, right: LogicalPlan, on: Vec<Expr>) -> LogicalPlan {
         left: Box::new(left),
         right: Box::new(right),
         on,
+        left_width: None,
+    })
+}
+
+/// [`join`], annotated with the left side's slot count — a pipe `|> JOIN`,
+/// whose output the later stages consume by position (see
+/// [`Join::left_width`]; `None` when the running outputs were already
+/// incomplete, so a positional trace refuses rather than guesses).
+fn pipe_join(
+    left: LogicalPlan,
+    right: LogicalPlan,
+    on: Vec<Expr>,
+    left_width: Option<usize>,
+) -> LogicalPlan {
+    LogicalPlan::Join(Join {
+        left: Box::new(left),
+        right: Box::new(right),
+        on,
+        left_width,
     })
 }
 

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -248,12 +248,27 @@ impl<'a> Binder<'a> {
                     .collect();
                 self.pipe_filter(input, reads)
             }
-            // `|> JOIN t ON …`: the joined table's scan surfaces (a table read),
-            // but — matching the resolver's loose pipe scoping — it is NOT added
-            // to the scope, so the ON predicate's references to it are
-            // unresolved (only the running relations resolve).
+            // `|> JOIN t ON … / USING (…)`: the joined relation enters the
+            // scope — the ON predicate and every later stage resolve it, and
+            // its `USING` / NATURAL merge columns fan in like a FROM-clause
+            // join (it used to stay out of scope, leaving the ON's right-side
+            // references unresolved). The running outputs gain the right
+            // side's columns after the left block (identity: they're base
+            // columns a later reference re-reads); a right side whose
+            // columns can't be enumerated makes the outputs incomplete.
             PipeOperator::Join(j) => {
-                let (right, _scope) = self.bind_table_factor(&j.relation, &scope.relations);
+                let (right, right_scope) = self.bind_table_factor(&j.relation, &scope.relations);
+                let merge = if join_is_natural(&j.join_operator) {
+                    self.natural_merge_columns(scope, &right_scope)
+                } else {
+                    join_using(&j.join_operator)
+                };
+                match pipe_join_output_cols(&right_scope.relations) {
+                    Some(cols) => scope.query_outputs.extend(cols),
+                    None => scope.outputs_complete = false,
+                }
+                scope.absorb(right_scope);
+                scope.add_merge_columns(merge);
                 let on = join_on(&j.join_operator)
                     .map(|e| self.bind_expr(e, scope))
                     .into_iter()
@@ -1130,4 +1145,42 @@ fn passthrough_exprs(base: &[OutputCol]) -> Vec<NamedExpr> {
             },
         })
         .collect()
+}
+
+/// The output columns a pipe `|> JOIN`'s right side appends to the running
+/// outputs — `None` when they can't be enumerated (an `Unknown` catalog-free
+/// table, an opaque table function, an incompletely-known derived relation),
+/// which makes the running outputs incomplete instead of presenting a
+/// partial list as the whole one.
+fn pipe_join_output_cols(relations: &[Relation]) -> Option<Vec<OutputCol>> {
+    let mut out = Vec::new();
+    for rel in relations {
+        match rel {
+            Relation::Table {
+                columns: Columns::Cataloged(cols),
+                ..
+            } => out.extend(cols.iter().map(|c| OutputCol {
+                name: Some(c.clone()),
+                identity: true,
+            })),
+            Relation::Derived {
+                columns:
+                    Exposed {
+                        slots,
+                        complete: true,
+                    },
+                ..
+            } => out.extend(slots.iter().map(|n| OutputCol {
+                name: n.clone(),
+                identity: false,
+            })),
+            Relation::Table {
+                columns: Columns::Unknown,
+                ..
+            }
+            | Relation::Derived { .. }
+            | Relation::TableFunction { .. } => return None,
+        }
+    }
+    Some(out)
 }

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -262,7 +262,7 @@ impl<'a> Binder<'a> {
                 // ([`Join::left_width`]). Unknowable when the running
                 // outputs are incomplete (a suppressed wildcard may hide
                 // slots), so record nothing and let the trace refuse.
-                let left_width = scope.outputs_complete.then(|| scope.query_outputs.len());
+                let left_width = scope.outputs_complete.then_some(scope.query_outputs.len());
                 let (right, right_scope) = self.bind_table_factor(&j.relation, &scope.relations);
                 // The NATURAL branch mirrors `bind_table_with_joins` for
                 // future-proofing, but is unreachable today: sqlparser 0.62

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -159,7 +159,7 @@ impl<'a> Binder<'a> {
         match op {
             PipeOperator::Select { exprs } => {
                 let (new, complete) = self.bind_output_items(exprs, scope);
-                let (node, query_outputs) = self.pipe_project(input, &[], new, &scope.relations);
+                let (node, query_outputs) = self.pipe_project(input, &[], new);
                 scope.query_outputs = query_outputs;
                 // A pipe SELECT replaces the outputs wholesale.
                 scope.outputs_complete = complete;
@@ -169,7 +169,7 @@ impl<'a> Binder<'a> {
                 // The new columns see the running outputs; then they append.
                 let (new, complete) = self.bind_output_items(exprs, scope);
                 let base = std::mem::take(&mut scope.query_outputs);
-                let (node, query_outputs) = self.pipe_project(input, &base, new, &scope.relations);
+                let (node, query_outputs) = self.pipe_project(input, &base, new);
                 scope.query_outputs = query_outputs;
                 // EXTEND appends to the running outputs, so both must be
                 // determinate.
@@ -196,7 +196,7 @@ impl<'a> Binder<'a> {
                         expr: self.bind_expr(&e.expr.expr, scope),
                     })
                     .collect();
-                let (node, query_outputs) = self.pipe_project(input, &[], new, &scope.relations);
+                let (node, query_outputs) = self.pipe_project(input, &[], new);
                 scope.query_outputs = query_outputs;
                 // AGGREGATE replaces the outputs with its own (wildcard-free)
                 // items.
@@ -286,20 +286,21 @@ impl<'a> Binder<'a> {
         (exprs, complete)
     }
 
-    /// Build an output-producing pipe `Projection`: the passthrough of `base`
-    /// outputs (each re-resolved by name against the base — an identity output
-    /// re-reads its real column, a computed output is `Derived` and traced)
-    /// plus the `new` value columns.
+    /// Build an output-producing pipe `Projection`: the positional passthrough
+    /// of the `base` outputs plus the `new` value columns. The passthrough
+    /// keeps each base `OutputCol` verbatim (name *and* identity — so a later
+    /// clause reference to an identity output still re-reads its real
+    /// column); only the `new` items mint fresh output metadata.
     pub(super) fn pipe_project(
         &mut self,
         input: LogicalPlan,
         base: &[OutputCol],
         new: Vec<NamedExpr>,
-        relations: &[Relation],
     ) -> (LogicalPlan, Vec<OutputCol>) {
-        let mut exprs = self.passthrough_exprs(base, relations);
+        let mut query_outputs = base.to_vec();
+        query_outputs.extend(self.output_cols(&new));
+        let mut exprs = passthrough_exprs(base);
         exprs.extend(new);
-        let query_outputs = self.output_cols(&exprs);
         (
             LogicalPlan::Projection(Projection {
                 input: Box::new(input),
@@ -307,31 +308,6 @@ impl<'a> Binder<'a> {
             }),
             query_outputs,
         )
-    }
-
-    /// Re-resolve each named `base` output as a passthrough projection item
-    /// (clause-alias resolution against the base, so an identity output
-    /// re-reads its real column while a computed output stays `Derived`).
-    pub(super) fn passthrough_exprs(
-        &self,
-        base: &[OutputCol],
-        relations: &[Relation],
-    ) -> Vec<NamedExpr> {
-        let pass_scope = Scope {
-            relations: relations.to_vec(),
-            query_outputs: base.to_vec(),
-            outputs_complete: false,
-            merge_columns: Vec::new(),
-        };
-        base.iter()
-            .filter_map(|o| o.name.clone())
-            .map(|name| NamedExpr {
-                expr: Expr::Column(Box::new(
-                    self.resolve(std::slice::from_ref(&name), &pass_scope),
-                )),
-                names: OutputNames::Single(Some(name)),
-            })
-            .collect()
     }
 
     /// `|> SET col = expr`: each assignment replaces a same-named base output in
@@ -343,24 +319,31 @@ impl<'a> Binder<'a> {
         assignments: &[sqlparser::ast::Assignment],
         scope: &Scope,
     ) -> (LogicalPlan, Vec<OutputCol>) {
-        let mut exprs = self.passthrough_exprs(&base, &scope.relations);
+        let mut exprs = passthrough_exprs(&base);
+        let mut query_outputs = base;
         for a in assignments {
             for column in assignment_target_columns(&a.target) {
                 let ne = NamedExpr {
                     names: OutputNames::Single(Some(column.clone())),
                     expr: self.bind_expr(&a.value, scope),
                 };
+                let replaced = self.output_cols(std::slice::from_ref(&ne)).remove(0);
                 // Pipe outputs are always single-named passthroughs.
-                match exprs.iter_mut().find(|e| {
+                match exprs.iter_mut().position(|e| {
                     matches!(&e.names, OutputNames::Single(Some(n))
                         if self.eq(self.style.casing.column, n, &column))
                 }) {
-                    Some(slot) => *slot = ne,
-                    None => exprs.push(ne),
+                    Some(i) => {
+                        exprs[i] = ne;
+                        query_outputs[i] = replaced;
+                    }
+                    None => {
+                        exprs.push(ne);
+                        query_outputs.push(replaced);
+                    }
                 }
             }
         }
-        let query_outputs = self.output_cols(&exprs);
         (
             LogicalPlan::Projection(Projection {
                 input: Box::new(input),
@@ -1044,4 +1027,24 @@ impl<'a> Binder<'a> {
             }
         }
     }
+}
+
+/// The positional passthrough of the running pipe outputs: one
+/// [`Expr::DerivedSlot`] per base output — **not** a read (the physical read
+/// is already counted at the producing stage, keeping reads
+/// occurrence-based), traced by position (so an anonymous output keeps its
+/// slot instead of being dropped and shifting the ones after it). The output
+/// name rides on the item; the base `OutputCol` itself is carried forward by
+/// the callers.
+fn passthrough_exprs(base: &[OutputCol]) -> Vec<NamedExpr> {
+    base.iter()
+        .enumerate()
+        .map(|(index, o)| NamedExpr {
+            names: OutputNames::Single(o.name.clone()),
+            expr: Expr::DerivedSlot {
+                qualifier: None,
+                index,
+            },
+        })
+        .collect()
 }

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -258,14 +258,23 @@ impl<'a> Binder<'a> {
             // columns can't be enumerated makes the outputs incomplete.
             PipeOperator::Join(j) => {
                 let (right, right_scope) = self.bind_table_factor(&j.relation, &scope.relations);
+                // The NATURAL branch mirrors `bind_table_with_joins` for
+                // future-proofing, but is unreachable today: sqlparser 0.62
+                // rejects `|> NATURAL JOIN` at parse time (verified).
                 let merge = if join_is_natural(&j.join_operator) {
                     self.natural_merge_columns(scope, &right_scope)
                 } else {
                     join_using(&j.join_operator)
                 };
                 match pipe_join_output_cols(&right_scope.relations) {
-                    Some(cols) => scope.query_outputs.extend(cols),
-                    None => scope.outputs_complete = false,
+                    Some(cols) if merge.is_empty() => scope.query_outputs.extend(cols),
+                    // A `USING` / NATURAL join coalesces the merge columns
+                    // into join-structure-dependent positions (the standard
+                    // puts them first) that a flat left-then-right
+                    // concatenation misstates — mark the outputs incomplete
+                    // instead, the same refusal `scope_star_slots` makes for
+                    // a bare `*` over a merged scope.
+                    _ => scope.outputs_complete = false,
                 }
                 scope.absorb(right_scope);
                 scope.add_merge_columns(merge);

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -257,6 +257,12 @@ impl<'a> Binder<'a> {
             // columns a later reference re-reads); a right side whose
             // columns can't be enumerated makes the outputs incomplete.
             PipeOperator::Join(j) => {
+                // The running slot count *before* the join — the bind-time
+                // truth a positional trace above the join splits at
+                // ([`Join::left_width`]). Unknowable when the running
+                // outputs are incomplete (a suppressed wildcard may hide
+                // slots), so record nothing and let the trace refuse.
+                let left_width = scope.outputs_complete.then(|| scope.query_outputs.len());
                 let (right, right_scope) = self.bind_table_factor(&j.relation, &scope.relations);
                 // The NATURAL branch mirrors `bind_table_with_joins` for
                 // future-proofing, but is unreachable today: sqlparser 0.62
@@ -282,7 +288,7 @@ impl<'a> Binder<'a> {
                     .map(|e| self.bind_expr(e, scope))
                     .into_iter()
                     .collect();
-                join(input, right, on)
+                pipe_join(input, right, on, left_width)
             }
             // `|> RENAME old AS new, …`: re-project the running outputs with
             // the mapped slots renamed. The new name is an introduced alias,

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -147,9 +147,11 @@ impl<'a> Binder<'a> {
     /// it reshapes the output. An output-producing operator (SELECT / EXTEND /
     /// SET / AGGREGATE) layers a [`Projection`] whose value expressions feed
     /// `QueryOutput` lineage; a filter operator (WHERE / ORDER BY / LIMIT /
-    /// CALL / PIVOT / set-op / JOIN) wraps a non-feeding read [`Filter`]; the
-    /// rest (sampling / rename / drop / unpivot) pass through. The match is
-    /// exhaustive so a new pipe operator is reviewed here.
+    /// CALL / PIVOT / set-op / JOIN) wraps a non-feeding read [`Filter`];
+    /// RENAME / DROP / AS reshape the running outputs (a positional
+    /// re-projection / an aliasing boundary); the rest (sampling / unpivot)
+    /// pass through. The match is exhaustive so a new pipe operator is
+    /// reviewed here.
     pub(super) fn bind_pipe(
         &mut self,
         op: &PipeOperator,
@@ -258,13 +260,94 @@ impl<'a> Binder<'a> {
                     .collect();
                 join(input, right, on)
             }
-            // No inspectable column expressions: a sampling clause, rename,
-            // drop, or unpivot.
-            PipeOperator::TableSample { .. }
-            | PipeOperator::Drop { .. }
-            | PipeOperator::As { .. }
-            | PipeOperator::Rename { .. }
-            | PipeOperator::Unpivot { .. } => input,
+            // `|> RENAME old AS new, …`: re-project the running outputs with
+            // the mapped slots renamed. The new name is an introduced alias,
+            // not the physical column, so its identity drops — a later
+            // reference to it traces through the projection instead of
+            // falling to the base relation (which fabricated a phantom
+            // read). With incomplete outputs the slot list is unknown, so
+            // the operator passes through unchanged (the unexpanded-`*`
+            // diagnostic already flags the gap); a mapping naming no known
+            // output is ignored, best-effort.
+            PipeOperator::Rename { mappings } => {
+                if !scope.outputs_complete {
+                    return input;
+                }
+                let mut outputs = std::mem::take(&mut scope.query_outputs);
+                for m in mappings {
+                    if let Some(o) = outputs.iter_mut().find(|o| {
+                        o.name
+                            .as_ref()
+                            .is_some_and(|n| self.eq(self.style.casing.column, n, &m.ident))
+                    }) {
+                        *o = OutputCol {
+                            name: Some(m.alias.clone()),
+                            identity: false,
+                        };
+                    }
+                }
+                let node = LogicalPlan::Projection(Projection {
+                    input: Box::new(input),
+                    exprs: passthrough_exprs(&outputs),
+                });
+                scope.query_outputs = outputs;
+                node
+            }
+            // `|> DROP col, …`: re-project without the dropped slots. Each
+            // kept slot's `DerivedSlot` keeps its *base* position (the slot
+            // indices below the projection don't move); only the exposed
+            // positions compact. Incomplete outputs pass through, as above.
+            PipeOperator::Drop { columns } => {
+                if !scope.outputs_complete {
+                    return input;
+                }
+                let kept: Vec<(usize, OutputCol)> = std::mem::take(&mut scope.query_outputs)
+                    .into_iter()
+                    .enumerate()
+                    .filter(|(_, o)| {
+                        !columns.iter().any(|c| {
+                            o.name
+                                .as_ref()
+                                .is_some_and(|n| self.eq(self.style.casing.column, n, c))
+                        })
+                    })
+                    .collect();
+                let exprs = kept
+                    .iter()
+                    .map(|(index, o)| NamedExpr {
+                        names: OutputNames::Single(o.name.clone()),
+                        expr: Expr::DerivedSlot {
+                            qualifier: None,
+                            index: *index,
+                        },
+                    })
+                    .collect();
+                scope.query_outputs = kept.into_iter().map(|(_, o)| o).collect();
+                LogicalPlan::Projection(Projection {
+                    input: Box::new(input),
+                    exprs,
+                })
+            }
+            // `|> AS u`: alias the whole running result, like a derived
+            // table's alias — the original relation qualifiers stop
+            // resolving (BigQuery drops them) and `u.col` addresses the
+            // running outputs through the `SubqueryAlias` boundary.
+            PipeOperator::As { alias } => {
+                scope.relations = vec![Relation::Derived {
+                    alias: Some(alias.clone()),
+                    columns: Exposed {
+                        slots: scope.query_outputs.iter().map(|o| o.name.clone()).collect(),
+                        complete: scope.outputs_complete,
+                    },
+                }];
+                LogicalPlan::SubqueryAlias(SubqueryAlias {
+                    alias: alias.clone(),
+                    input: Box::new(input),
+                })
+            }
+            // No inspectable column expressions: a sampling clause or
+            // unpivot.
+            PipeOperator::TableSample { .. } | PipeOperator::Unpivot { .. } => input,
         }
     }
 

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -432,15 +432,17 @@ pub(crate) enum Expr {
     /// — each a `Passthrough` read / origin (one per side, not an ambiguous
     /// `table: None`).
     Fanin(Vec<BoundColumn>),
-    /// A wildcard-expansion-synthesized reference to the `index`-th output
-    /// slot of the derived relation exposed as `qualifier` — **positional by
-    /// construction** (the expansion enumerates the producer's slots), so a
-    /// duplicate output name (`SELECT o.id, c.id` in the producer) or an
-    /// anonymous one can't misattribute the trace the way a name-keyed
-    /// `Derived` lookup would. Never minted for written SQL: a *written*
-    /// reference resolves by name (`Expr::Column`). Like any `Derived` ref it
-    /// is not a read (the physical read is counted at the inner producer);
-    /// `origins` traces it to the producer's `index`-th output.
+    /// A synthesized reference to the `index`-th output slot of the producer
+    /// exposed as `qualifier` (`None` = the inline / running one) —
+    /// **positional by construction**, so a duplicate output name
+    /// (`SELECT o.id, c.id` in the producer) or an anonymous one can't
+    /// misattribute the trace the way a name-keyed `Derived` lookup would.
+    /// Minted by wildcard expansion (one per expanded column) and by the
+    /// pipe-operator passthrough (one per carried-forward running output);
+    /// never for written SQL — a *written* reference resolves by name
+    /// (`Expr::Column`). Like any `Derived` ref it is not a read (the
+    /// physical read is counted at the inner producer); `origins` traces it
+    /// to the producer's `index`-th output.
     DerivedSlot {
         qualifier: Option<Ident>,
         index: usize,

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -100,6 +100,15 @@ pub(crate) struct Join {
     pub(crate) left: Box<LogicalPlan>,
     pub(crate) right: Box<LogicalPlan>,
     pub(crate) on: Vec<Expr>,
+    /// A positionally-consumed join's output split: the left side's slot
+    /// count, recorded at bind time. Set on a pipe `|> JOIN` — the only
+    /// join whose output later stages reference *by position* (passthrough
+    /// / star slots) — from the binder's running output count, so a
+    /// positional trace splits left-vs-right by reading it instead of
+    /// re-deriving the width from the tree (the re-derivation misrouted
+    /// stacked joins). `None` = the projection above owns the output shape
+    /// (every FROM-clause join).
+    pub(crate) left_width: Option<usize>,
 }
 
 /// Aggregate (Γ): the `GROUP BY` grouping over its input, sitting below the

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -228,6 +228,27 @@ fn origins_of_slot<'a>(
         LogicalPlan::Filter(f) => origins_of_slot(&f.input, qualifier, index, context),
         LogicalPlan::Sort(s) => origins_of_slot(&s.input, qualifier, index, context),
         LogicalPlan::Join(j) => {
+            // An *unqualified* slot over a join is a pipe passthrough / star
+            // slot above a `|> JOIN`, whose output concatenates the left
+            // block's slots then the right side's columns — the index
+            // belongs to exactly one side, split at the left side's full
+            // width ([`slot_width`], which sums a stacked join's both sides
+            // — the first-operand count undercounted there and misrouted a
+            // middle join's slots to the outer right side). Letting both
+            // sides answer at the same index — the qualified behaviour
+            // below — would misclaim: a derived right side has no qualifier
+            // guard to stop it from answering for a left slot. An
+            // uncountable left side can't locate the split, so nothing is
+            // claimed rather than guessed.
+            if qualifier.is_none() {
+                return match slot_width(&j.left) {
+                    Some(n) if index < n => origins_of_slot(&j.left, qualifier, index, context),
+                    Some(n) => origins_of_slot(&j.right, qualifier, index - n, context),
+                    None => Vec::new(),
+                };
+            }
+            // A qualified slot resolves by relation boundary: each side's
+            // `SubqueryAlias` / `CteRef` guard admits exactly one owner.
             let mut o = origins_of_slot(&j.left, qualifier, index, context);
             o.extend(origins_of_slot(&j.right, qualifier, index, context));
             o
@@ -727,6 +748,37 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
         | LogicalPlan::CreateView(_)
         | LogicalPlan::AlterTable(_)
         | LogicalPlan::Drop(_) => {}
+    }
+}
+
+/// The number of output slots `op` exposes, when statically knowable: a
+/// projection's slot count, a set operation's first branch, a join's two
+/// sides summed, VALUES rows' width — through the transparent wrappers.
+/// `None` when a side exposes no positional producer (a raw scan, an opaque
+/// table function, a CTE reference), where a count would be a guess.
+fn slot_width(op: &LogicalPlan) -> Option<usize> {
+    match op {
+        LogicalPlan::Projection(p) => Some(output_slots(&p.exprs).count()),
+        LogicalPlan::SetOp(so) => slot_width(&so.left),
+        LogicalPlan::SubqueryAlias(sa) => slot_width(&sa.input),
+        LogicalPlan::Filter(f) => slot_width(&f.input),
+        LogicalPlan::Sort(s) => slot_width(&s.input),
+        LogicalPlan::Aggregate(a) => slot_width(&a.input),
+        LogicalPlan::With(w) => slot_width(&w.body),
+        LogicalPlan::Join(j) => Some(slot_width(&j.left)? + slot_width(&j.right)?),
+        LogicalPlan::Values(v) => v.rows.first().map(Vec::len),
+        LogicalPlan::Scan(_)
+        | LogicalPlan::TableFunction(_)
+        | LogicalPlan::CteRef(_)
+        | LogicalPlan::Empty
+        | LogicalPlan::Insert(_)
+        | LogicalPlan::Update(_)
+        | LogicalPlan::Delete(_)
+        | LogicalPlan::Merge(_)
+        | LogicalPlan::CreateTableAs(_)
+        | LogicalPlan::CreateView(_)
+        | LogicalPlan::AlterTable(_)
+        | LogicalPlan::Drop(_) => None,
     }
 }
 

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -231,17 +231,17 @@ fn origins_of_slot<'a>(
             // An *unqualified* slot over a join is a pipe passthrough / star
             // slot above a `|> JOIN`, whose output concatenates the left
             // block's slots then the right side's columns — the index
-            // belongs to exactly one side, split at the left side's full
-            // width ([`slot_width`], which sums a stacked join's both sides
-            // — the first-operand count undercounted there and misrouted a
-            // middle join's slots to the outer right side). Letting both
-            // sides answer at the same index — the qualified behaviour
-            // below — would misclaim: a derived right side has no qualifier
-            // guard to stop it from answering for a left slot. An
-            // uncountable left side can't locate the split, so nothing is
-            // claimed rather than guessed.
+            // belongs to exactly one side, split at the bind-time recorded
+            // left width ([`Join::left_width`]: the binder's running slot
+            // count, so a stacked join carries its own truth instead of the
+            // walk re-deriving it). Letting both sides answer at the same
+            // index — the qualified behaviour below — would misclaim: a
+            // derived right side has no qualifier guard to stop it from
+            // answering for a left slot. An unannotated join (a FROM-clause
+            // join, or a pipe join over already-incomplete outputs) claims
+            // nothing rather than guessing.
             if qualifier.is_none() {
-                return match slot_width(&j.left) {
+                return match j.left_width {
                     Some(n) if index < n => origins_of_slot(&j.left, qualifier, index, context),
                     Some(n) => origins_of_slot(&j.right, qualifier, index - n, context),
                     None => Vec::new(),
@@ -748,37 +748,6 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
         | LogicalPlan::CreateView(_)
         | LogicalPlan::AlterTable(_)
         | LogicalPlan::Drop(_) => {}
-    }
-}
-
-/// The number of output slots `op` exposes, when statically knowable: a
-/// projection's slot count, a set operation's first branch, a join's two
-/// sides summed, VALUES rows' width — through the transparent wrappers.
-/// `None` when a side exposes no positional producer (a raw scan, an opaque
-/// table function, a CTE reference), where a count would be a guess.
-fn slot_width(op: &LogicalPlan) -> Option<usize> {
-    match op {
-        LogicalPlan::Projection(p) => Some(output_slots(&p.exprs).count()),
-        LogicalPlan::SetOp(so) => slot_width(&so.left),
-        LogicalPlan::SubqueryAlias(sa) => slot_width(&sa.input),
-        LogicalPlan::Filter(f) => slot_width(&f.input),
-        LogicalPlan::Sort(s) => slot_width(&s.input),
-        LogicalPlan::Aggregate(a) => slot_width(&a.input),
-        LogicalPlan::With(w) => slot_width(&w.body),
-        LogicalPlan::Join(j) => Some(slot_width(&j.left)? + slot_width(&j.right)?),
-        LogicalPlan::Values(v) => v.rows.first().map(Vec::len),
-        LogicalPlan::Scan(_)
-        | LogicalPlan::TableFunction(_)
-        | LogicalPlan::CteRef(_)
-        | LogicalPlan::Empty
-        | LogicalPlan::Insert(_)
-        | LogicalPlan::Update(_)
-        | LogicalPlan::Delete(_)
-        | LogicalPlan::Merge(_)
-        | LogicalPlan::CreateTableAs(_)
-        | LogicalPlan::CreateView(_)
-        | LogicalPlan::AlterTable(_)
-        | LogicalPlan::Drop(_) => None,
     }
 }
 

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -698,6 +698,10 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
             collect_operands(&so.left, ctes, out);
             collect_operands(&so.right, ctes, out);
         }
+        // An aliasing boundary renames the *relation*, not the columns — the
+        // input's outputs are exposed unchanged (a pipe `|> AS u` sits right
+        // on the statement's output path).
+        LogicalPlan::SubqueryAlias(sa) => collect_operands(&sa.input, ctes, out),
         // No projection at this level — a relation that doesn't carry a
         // SELECT list (a `Scan`, a join below a projection, a DML / DDL root,
         // …) yields no operands. Listed explicitly so a new operator that
@@ -705,7 +709,6 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
         LogicalPlan::Scan(_)
         | LogicalPlan::Join(_)
         | LogicalPlan::Aggregate(_)
-        | LogicalPlan::SubqueryAlias(_)
         | LogicalPlan::TableFunction(_)
         | LogicalPlan::CteRef(_)
         | LogicalPlan::Values(_)

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -702,12 +702,18 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
         // input's outputs are exposed unchanged (a pipe `|> AS u` sits right
         // on the statement's output path).
         LogicalPlan::SubqueryAlias(sa) => collect_operands(&sa.input, ctes, out),
+        // A join on the output path is a pipe `|> JOIN` above the running
+        // projection: the join's output keeps the left block's slots first
+        // (the right side's columns follow it), so the left branch carries
+        // the positional operands — a right-side slot has no operand and
+        // stays edge-less, best-effort. (A join *below* a projection never
+        // reaches here — the projection claims the walk first.)
+        LogicalPlan::Join(jn) => collect_operands(&jn.left, ctes, out),
         // No projection at this level — a relation that doesn't carry a
         // SELECT list (a `Scan`, a join below a projection, a DML / DDL root,
         // …) yields no operands. Listed explicitly so a new operator that
         // *does* expose columns positionally forces an explicit handler.
         LogicalPlan::Scan(_)
-        | LogicalPlan::Join(_)
         | LogicalPlan::Aggregate(_)
         | LogicalPlan::TableFunction(_)
         | LogicalPlan::CteRef(_)

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1484,6 +1484,55 @@ mod pipe_join {
     }
 
     #[test]
+    fn fan_slots_and_a_derived_right_side_split_consistently() {
+        // The bind-time width counts fan slots the same way the slot view
+        // does (2 for `AS (k, v)`), so the star's slots 0-1 trace the fan's
+        // argument and slot 2 lands on the derived right side.
+        assert_column_ops(
+            "SELECT explode(arr) AS (k, v) FROM t              |> JOIN (SELECT id FROM u) x ON 1 = 1 |> SELECT *",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "arr"), read("u", "id")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("t", "arr"), out("k", 0)),
+                    transformation(col("t", "arr"), out("v", 1)),
+                    passthrough(col("u", "id"), out("id", 2)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn unqualified_ref_after_a_join_is_open_world_ambiguous() {
+        // After the join, an unqualified `a` has two catalog-free suspects
+        // (the base `t` and the joined `u`), so it surfaces `Ambiguous` —
+        // the same open-world rule as `SELECT a FROM t, u`. A catalog that
+        // rules `u` out would pin it back to `t`.
+        assert_column_ops(
+            "FROM t |> SELECT a, b |> JOIN u ON a = u.id |> EXTEND a + 1 AS c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read("t", "a"),
+                    read("t", "b"),
+                    ambiguous("a"),
+                    read("u", "id"),
+                    ambiguous("a"),
+                ],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    passthrough(col("t", "b"), out("b", 1)),
+                    transformation(ambiguous("a"), out("c", 2)),
+                ],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
     fn join_using_merge_column_fans_in_downstream() {
         // The WHERE's `k` fans in to both sides of the pipe join, exactly
         // like the same USING join written in a FROM clause.

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1325,6 +1325,38 @@ mod pipe_reshape {
     }
 
     #[test]
+    fn drop_over_incomplete_outputs_passes_through() {
+        // Same rule as RENAME below: with unknown running outputs the DROP
+        // can't re-project, so the dropped name still resolves best-effort.
+        assert_column_ops(
+            "FROM t |> DROP a |> SELECT a",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn tablesample_passes_through() {
+        // A sampling clause has no column expressions — the chain continues
+        // over the same scope.
+        assert_column_ops(
+            "FROM t |> TABLESAMPLE SYSTEM (10 PERCENT) |> SELECT a",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
     fn rename_over_incomplete_outputs_passes_through() {
         // Catalog-free `FROM t` leaves the running outputs unknown, so the
         // RENAME can't re-project — the reference still falls to the base
@@ -1377,6 +1409,76 @@ mod pipe_join {
                 writes: vec![],
                 lineage: vec![passthrough(col("t", "a"), out("a", 0))],
                 diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn join_derived_right_side_slots_split_positionally() {
+        // The trailing star's slots split at the left block's width: slot 0
+        // is the running `a` (left), slot 1 the derived side's `id` (right,
+        // at its own offset). Both sides answering at the same index used
+        // to let the derived right side misclaim slot 0 (`u.id -> a`).
+        assert_column_ops(
+            "FROM t |> SELECT a |> JOIN (SELECT id FROM u) v ON a = v.id |> SELECT *",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("u", "id"), read("t", "a")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    passthrough(col("u", "id"), out("id", 1)),
+                ],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn stacked_derived_joins_split_at_the_full_left_width() {
+        // The split point is the left side's *full* width — a stacked join
+        // sums both of its sides — so each derived side's slot routes to its
+        // own producer (the first-operand count undercounted the middle
+        // join's width and misrouted `p`'s slot to `q`).
+        assert_column_ops(
+            "FROM t |> SELECT a              |> JOIN (SELECT x FROM u) p ON a = p.x              |> JOIN (SELECT y FROM w) q ON a = q.y              |> SELECT *",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read("t", "a"),
+                    read("u", "x"),
+                    read("t", "a"),
+                    read("w", "y"),
+                    read("t", "a"),
+                ],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    passthrough(col("u", "x"), out("x", 1)),
+                    passthrough(col("w", "y"), out("y", 2)),
+                ],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn fan_output_passthrough_keeps_both_slots() {
+        // A multi-alias fan (`explode(arr) AS (k, v)`) occupies two slots
+        // with one expression; the EXTEND passthrough carries both
+        // positionally (the slot view expands the fan), so each fan output
+        // still traces to the argument.
+        assert_column_ops(
+            "SELECT explode(arr) AS (k, v) FROM t |> EXTEND 1 AS y",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "arr")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("t", "arr"), out("k", 0)),
+                    transformation(col("t", "arr"), out("v", 1)),
+                ],
+                diagnostics: vec![],
             },
         );
     }

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1170,3 +1170,86 @@ mod output_alias_visibility {
         );
     }
 }
+
+mod pipe_passthrough {
+    //! An output-producing pipe stage carries the running outputs forward as
+    //! *positional* passthroughs: not re-reads (reads stay occurrence-based
+    //! — the physical read was counted at the producing stage), position-
+    //! preserving (an anonymous output keeps its slot), traced by position.
+    //! The catalog-free `FROM t` base leaves the implicit `*` unexpanded,
+    //! hence the `WildcardSuppressed` flag on each case.
+    use super::*;
+
+    #[test]
+    fn extend_does_not_reread_the_carried_identity_output() {
+        // `a` is written once; the EXTEND passthrough must not mint a second
+        // `t.a` read at the same span (it used to re-resolve by name).
+        assert_column_ops(
+            "FROM t |> SELECT a |> EXTEND 1 AS y",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn anonymous_output_keeps_its_slot_through_a_later_stage() {
+        // The unaliased `t.a + t.b` used to be dropped from the passthrough,
+        // shifting `y` into its position and losing its lineage; it now
+        // keeps slot #0 (traced positionally) with `y` after it.
+        assert_column_ops(
+            "FROM t |> SELECT t.a + t.b |> EXTEND 1 AS y",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("t", "a"), out_anon(0)),
+                    transformation(col("t", "b"), out_anon(0)),
+                ],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn a_written_clause_reference_to_an_identity_output_still_reads() {
+        // The passthrough carries the base output's *identity* flag, so a
+        // later written occurrence (`WHERE a > 0`) still re-reads the real
+        // column — only the synthesized passthrough is read-free.
+        assert_column_ops(
+            "FROM t |> SELECT a |> EXTEND 1 AS y |> WHERE a > 0",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn set_replaces_the_slot_without_rereading_the_others() {
+        // `SET b = a + 1` rewrites `b`'s slot in place: the carried `a`
+        // isn't re-read, the RHS `a` is (a written occurrence), and `b`'s
+        // only read is its SELECT occurrence.
+        assert_column_ops(
+            "FROM t |> SELECT a, b |> SET b = a + 1",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b"), read("t", "a")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    transformation(col("t", "a"), out("b", 1)),
+                ],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1253,3 +1253,107 @@ mod pipe_passthrough {
         );
     }
 }
+
+mod pipe_reshape {
+    //! `|> RENAME` / `|> DROP` / `|> AS` reshape the running outputs (they
+    //! used to pass through untouched, so a renamed / dropped name fell to
+    //! the base relation as a phantom read). With incomplete running
+    //! outputs (a catalog-free `FROM t` base) RENAME / DROP still pass
+    //! through — the slot list is unknown — under the existing
+    //! `WildcardSuppressed` flag.
+    use super::*;
+
+    #[test]
+    fn rename_redirects_a_later_reference_to_the_renamed_slot() {
+        // `b` after the RENAME is the renamed `a` slot — a Derived
+        // reference traced to `t.a` — not a phantom base column `t.b`.
+        assert_column_ops(
+            "FROM t |> SELECT a, c |> RENAME a AS b |> SELECT b",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "c")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("b", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn drop_removes_the_slot_and_compacts_the_positions() {
+        // After `DROP a` the running outputs are (b), so the EXTENDed `y`
+        // lands at position 1 and only `b` carries output lineage; `a`'s
+        // SELECT read survives (occurrence-based).
+        assert_column_ops(
+            "FROM t |> SELECT a, b |> DROP a |> EXTEND 1 AS y",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "b"), out("b", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn as_aliases_the_running_result_and_retires_the_base_qualifiers() {
+        // `u.a` addresses the aliased running result (a Derived reference,
+        // traced through the boundary — the output lineage survives it).
+        assert_column_ops(
+            "FROM t |> SELECT a |> AS u |> WHERE u.a > 0",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+        // The original relation's qualifier stops resolving past the alias
+        // (BigQuery drops it) — surfaced unresolved, not silently bound.
+        assert_column_ops(
+            "FROM t |> SELECT a |> AS u |> WHERE t.a > 0",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), unresolved("a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn rename_over_incomplete_outputs_passes_through() {
+        // Catalog-free `FROM t` leaves the running outputs unknown, so the
+        // RENAME can't re-project — the reference still falls to the base
+        // relation, best-effort, under the unexpanded-`*` flag.
+        assert_column_ops(
+            "FROM t |> RENAME a AS b |> SELECT b",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "b")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "b"), out("b", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn insert_pairs_through_a_pipe_alias() {
+        // The aliasing boundary renames the relation, not the columns — the
+        // INSERT still pairs the running output to its target column.
+        assert_column_ops(
+            "INSERT INTO dst (x) FROM t |> SELECT a |> AS u",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("t", "a")],
+                writes: vec![write("dst", "x")],
+                lineage: vec![passthrough(col("t", "a"), relation("dst", "x"))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1357,3 +1357,51 @@ mod pipe_reshape {
         );
     }
 }
+
+mod pipe_join {
+    //! `|> JOIN` brings the joined relation into the running scope: the ON
+    //! predicate and every later stage resolve it, and its USING merge
+    //! columns fan in like a FROM-clause join. (It used to stay out of
+    //! scope — the ON's right-side references fell unresolved — and the
+    //! `Join` node blocked the output-operand walk, dropping all output
+    //! lineage.)
+    use super::*;
+
+    #[test]
+    fn join_right_side_resolves_and_output_lineage_survives() {
+        assert_column_ops(
+            "FROM t |> SELECT t.a |> JOIN u ON t.a = u.id",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "a"), read("u", "id")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
+    fn join_using_merge_column_fans_in_downstream() {
+        // The WHERE's `k` fans in to both sides of the pipe join, exactly
+        // like the same USING join written in a FROM clause.
+        assert_column_ops(
+            "FROM t |> SELECT a, k |> JOIN u USING (k) |> WHERE k > 0",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read("t", "a"),
+                    read("t", "k"),
+                    read("t", "k"),
+                    read("u", "k"),
+                ],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    passthrough(col("t", "k"), out("k", 1)),
+                ],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
+++ b/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
@@ -1283,6 +1283,33 @@ mod implicit_star {
     }
 
     #[test]
+    fn pipe_select_star_after_a_pipe_join_covers_both_sides() {
+        // A pipe JOIN appends the right side's cataloged columns to the
+        // running outputs, so the trailing `|> SELECT *` stays complete (no
+        // suppression): slots (a, id, v). Only the left block's slots have
+        // positional operands under the `Join` node — the right-side slots
+        // surface positionally without lineage edges, best-effort.
+        let catalog = TestCatalog::default()
+            .with("t", vec!["a"])
+            .with("u", vec!["id", "v"]);
+        assert_column_ops_with_catalog(
+            "FROM t |> JOIN u ON t.a = u.id |> SELECT *",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    expanded_read("t", "a"),
+                    read_with_ref(cataloged_table("t"), "a", ResolutionKind::Cataloged),
+                    read_with_ref(cataloged_table("u"), "id", ResolutionKind::Cataloged),
+                ],
+                writes: vec![],
+                lineage: vec![passthrough(expanded_read("t", "a"), expanded_out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn outer_wildcard_expands_through_a_from_first_derived_body() {
         // The derived body's implicit `*` expands (catalog), completing the
         // slot view — so the outer `*` expands through it. Previously the

--- a/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
+++ b/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
@@ -1310,6 +1310,29 @@ mod implicit_star {
     }
 
     #[test]
+    fn pipe_select_star_after_a_using_pipe_join_stays_suppressed() {
+        // `USING` coalesces the merge column into a join-structure-dependent
+        // position (the standard puts it first) that a flat left-then-right
+        // concatenation would misstate — the join marks the running outputs
+        // incomplete, so the trailing star stays suppressed: the same
+        // refusal a bare `*` over a merged FROM scope makes.
+        let catalog = TestCatalog::default()
+            .with("t", vec!["a", "k"])
+            .with("u", vec!["k", "v"]);
+        assert_column_ops_with_catalog(
+            "FROM t |> JOIN u USING (k) |> SELECT *",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![expanded_read("t", "a"), expanded_read("t", "k")],
+                writes: vec![],
+                lineage: vec![],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
     fn outer_wildcard_expands_through_a_from_first_derived_body() {
         // The derived body's implicit `*` expands (catalog), completing the
         // slot view — so the outer `*` expands through it. Previously the


### PR DESCRIPTION
## Summary

Four bugs in the BigQuery pipe-syntax (`|>`) binding, all rooted in the pipe chain's running scope not evolving the way the operators demand. Each verified against the live CLI before and after.

- **The passthrough re-resolved the running outputs by name**, which broke two ways: an anonymous output (`FROM t |> SELECT t.a + t.b |> EXTEND 1 AS y`) was dropped outright — shifting every later slot, losing its lineage, and leaving the positions marked complete so DML pairing misattributed — and an identity output was re-read at its original span on every later stage (`|> SELECT a |> EXTEND 1 AS y` counted `t.a` twice, breaking occurrence-based reads). Each base output is now carried as a positional `Expr::DerivedSlot` — not a read, position-preserving, traced by slot — with its output metadata (name and identity) forwarded verbatim, so a later *written* reference to an identity output still re-reads the real column and `|> SET` still replaces by name.
- **`|> RENAME` / `|> DROP` / `|> AS` passed through without touching the scope**, so a renamed or dropped name kept resolving against the base relation — `FROM t |> RENAME a AS b |> SELECT b` fabricated a phantom `t.b` read — and `|> AS` left the original qualifiers live. RENAME now re-projects the slots under the mapped names (identity drops: the new name is an introduced alias), DROP re-projects without the dropped slots (kept slots keep their base positions), and AS wraps the chain in a `SubqueryAlias` whose alias replaces the relations — `u.col` resolves, the retired base qualifiers surface unresolved (matching BigQuery, which drops them). With incomplete running outputs (a catalog-free FROM-first base) RENAME / DROP still pass through under the existing unexpanded-`*` diagnostic — the slot list is unknown, so re-projecting would guess.
- **`|> JOIN` left the joined relation out of the running scope**, so the ON predicate's right-side references fell unresolved (`FROM t |> SELECT t.a |> JOIN u ON t.a = u.id` read an unresolved `id`), and the `Join` node it layers above the running projection blocked the output-operand walk — dropping every output lineage edge of the chain. The joined relation now enters the scope like a FROM-clause join (absorb + `USING` / NATURAL merge columns, so an unqualified merge reference fans in downstream), and the running outputs gain the right side's columns when they're enumerable (else they go incomplete).
- **A follow-up coverage sweep found two positional holes in the join handling, both fixed.** An unqualified slot traced over a `Join` let both sides answer at the same index, so a derived right side — which has no qualifier guard — misclaimed the left block's slots (`FROM t |> SELECT a |> JOIN (SELECT id FROM u) v` traced `u.id` into slot 0), and the naive width undercounted a stacked join's left side, misrouting a middle join's slots to the outer right. The trace now splits at the left side's full slot width — which also gives right-side derived slots their correct positional edges. Rather than re-deriving that width from the tree (the re-computation was the source of both holes), the `Join` node now carries it: `left_width`, recorded at bind time from the binder's running output count (only when the outputs are complete; `None` on every FROM-clause join, whose output shape the projection above owns), so a stacked join holds its own truth at every level and a join over already-incomplete outputs refuses positional claims instead of guessing. And a `USING` pipe join now marks the running outputs incomplete instead of appending a flat left-then-right list: the coalesced merge column sits at a join-structure-dependent position the concatenation would misstate — the same refusal a bare `*` over a merged FROM scope makes.
- **Output-operand collection learned two pass-throughs** the new plan shapes need: `SubqueryAlias` (an aliasing boundary renames the relation, not the columns — a trailing `|> AS` no longer hides the outputs) and a `Join`'s left branch (the left block's slots keep their positions; a right-side slot has no positional operand and stays edge-less, best-effort).

## Tests

Three new pin modules — `pipe_passthrough` (identity not re-read, anonymous slot kept, written clause reference still reads, SET replaces in place), `pipe_reshape` (RENAME redirect, DROP compaction, AS aliasing both ways, the incomplete-outputs pass-through, INSERT pairing through a pipe alias), `pipe_join` (right side resolves + lineage survives, USING fan-in downstream) — plus catalog pins that `|> SELECT *` after an ON pipe join covers both sides without suppression while a USING join stays suppressed, the stacked-derived-join slot split, the fan-output passthrough, the DROP / TABLESAMPLE pass-throughs, and the incomplete-outputs DROP. Full workspace: 900 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


