### PR TITLE
fix: close the remaining audited correctness gaps across dialect corners

### DIFF
--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -78,8 +78,10 @@ pub struct CrudTables {
     /// Tables deleted (`DELETE` / `DROP` / `TRUNCATE` / a MERGE DELETE action).
     pub delete_tables: Vec<TableWrite>,
     /// Non-fatal diagnostics, forwarded from the underlying table-level
-    /// extraction (only [`UnsupportedStatement`](crate::diagnostic::TableLevelDiagnosticKind::UnsupportedStatement)
-    /// arises at this granularity).
+    /// extraction — the table-granularity kinds:
+    /// [`UnsupportedStatement`](crate::diagnostic::TableLevelDiagnosticKind::UnsupportedStatement)
+    /// and
+    /// [`TooManyTableQualifiers`](crate::diagnostic::TableLevelDiagnosticKind::TooManyTableQualifiers).
     pub diagnostics: Vec<TableLevelDiagnostic>,
 }
 

--- a/sql-insight/src/extractor/crud_table_extractor.rs
+++ b/sql-insight/src/extractor/crud_table_extractor.rs
@@ -27,7 +27,7 @@ use crate::diagnostic::TableLevelDiagnostic;
 use crate::error::Error;
 use crate::extractor::{ExtractorOptions, StatementKind, TableOperationExtractor};
 use crate::reference::{TableRead, TableReference, TableWrite};
-use sqlparser::ast::{Insert, SetExpr, Statement};
+use sqlparser::ast::{Insert, SetExpr, SqliteOnConflict, Statement};
 use sqlparser::dialect::Dialect;
 
 /// Parse `sql` under `dialect` and return one [`CrudTables`] per
@@ -169,10 +169,14 @@ impl CrudTableExtractor {
                 }
                 // `REPLACE INTO` / `INSERT OVERWRITE` delete the conflicting /
                 // existing rows of the target before inserting, so the target is
-                // also a delete (unlike an upsert, which updates in place). Peel
-                // a `WITH … INSERT OVERWRITE …` wrapper (parsed as a Query-
+                // also a delete (unlike an upsert, which updates in place).
+                // SQLite spells it `INSERT OR REPLACE` (its bare `REPLACE INTO`
+                // parses to the same `or` field, not `replace_into`). Peel a
+                // `WITH … INSERT OVERWRITE …` wrapper (parsed as a Query-
                 // wrapped Insert) so the flags are read off the real insert.
-                if peel_to_insert(statement).is_some_and(|i| i.replace_into || i.overwrite) {
+                if peel_to_insert(statement).is_some_and(|i| {
+                    i.replace_into || i.overwrite || i.or == Some(SqliteOnConflict::Replace)
+                }) {
                     crud.delete_tables = writes.clone();
                 }
                 crud.create_tables = writes;

--- a/sql-insight/src/extractor/table_operation_extractor.rs
+++ b/sql-insight/src/extractor/table_operation_extractor.rs
@@ -101,7 +101,7 @@ pub struct TableOperation {
     pub lineage: Vec<TableLineageEdge>,
     /// Non-fatal diagnostics from the walk — the table-granularity kinds:
     /// `UnsupportedStatement` and `TooManyTableQualifiers` (see
-    /// [`TableLevelDiagnosticKind`](crate::diagnostic::TableLevelDiagnosticKind)).
+    /// [`TableLevelDiagnosticKind`]).
     pub diagnostics: Vec<TableLevelDiagnostic>,
 }
 

--- a/sql-insight/src/extractor/table_operation_extractor.rs
+++ b/sql-insight/src/extractor/table_operation_extractor.rs
@@ -99,8 +99,9 @@ pub struct TableOperation {
     /// two edges — but a CTE body, the one declaration shared by every
     /// `CteRef`, contributes once (it materializes once, so it feeds once).
     pub lineage: Vec<TableLineageEdge>,
-    /// Non-fatal diagnostics from the walk; only
-    /// `UnsupportedStatement` arises at this granularity.
+    /// Non-fatal diagnostics from the walk — the table-granularity kinds:
+    /// `UnsupportedStatement` and `TooManyTableQualifiers` (see
+    /// [`TableLevelDiagnosticKind`](crate::diagnostic::TableLevelDiagnosticKind)).
     pub diagnostics: Vec<TableLevelDiagnostic>,
 }
 

--- a/sql-insight/src/normalizer.rs
+++ b/sql-insight/src/normalizer.rs
@@ -166,7 +166,14 @@ impl VisitorMut for Normalizer {
             }) = stmt
             {
                 if let Some(Query { body, .. }) = source.as_deref() {
-                    if let SetExpr::Values(v) = body.deref() {
+                    // A parenthesized source (`INSERT … (VALUES …)`) nests
+                    // the VALUES under a `SetExpr::Query` — peel to it, so
+                    // both spellings alphabetize alike.
+                    let mut body = body.deref();
+                    while let SetExpr::Query(q) = body {
+                        body = q.body.deref();
+                    }
+                    if let SetExpr::Values(v) = body {
                         // `Parens` equality ignores its parenthesis tokens
                         // (their `PartialEq` is always-equal), so this compares
                         // the row content alone — matching the sentinel above.

--- a/sql-insight/src/resolver/binder.rs
+++ b/sql-insight/src/resolver/binder.rs
@@ -764,9 +764,15 @@ fn inferred_name(expr: &SqlExpr) -> Option<Ident> {
 
 /// The name of the query output a positional ordinal key (`GROUP BY 1` /
 /// `ORDER BY 1`) refers to — the 1-based n-th [`Scope::query_outputs`] entry,
-/// if it has one. `None` for a non-integer / zero / out-of-range position, or
-/// an anonymous output: the caller then binds the literal as written.
+/// if it has one. `None` for a non-integer / zero / out-of-range position, an
+/// anonymous output, or **incomplete** outputs (an unexpanded wildcard hides
+/// slots, so the n-th entry isn't the n-th output — `SELECT *, a … ORDER BY
+/// 1` must not bind the ordinal to `a`): the caller then binds the literal
+/// as written.
 fn ordinal_output_name(expr: &SqlExpr, scope: &Scope) -> Option<Ident> {
+    if !scope.outputs_complete {
+        return None;
+    }
     let SqlExpr::Value(v) = expr else {
         return None;
     };

--- a/sql-insight/src/resolver/binder/context.rs
+++ b/sql-insight/src/resolver/binder/context.rs
@@ -45,6 +45,15 @@ pub(super) struct Context {
     /// enclosing query relations (correlation) and lambda parameters, each at
     /// its lexical depth. See [`Level`].
     pub(super) outer: Vec<Level>,
+    /// The `EXCLUDED` pseudo-relation's columns while binding a conflict
+    /// action (`ON CONFLICT DO UPDATE` / `ON DUPLICATE KEY UPDATE`), else
+    /// empty. An unqualified reference to one is contested between the
+    /// existing target row and `EXCLUDED` (PostgreSQL rejects it as
+    /// ambiguous), so resolution demotes it — a *rule*, not a post-pass, so
+    /// it reaches a correlated reference inside a subquery of the action
+    /// too. Carried into child contexts like the stack (a subquery stays
+    /// inside the conflict action).
+    pub(super) excluded_columns: Vec<Ident>,
 }
 
 impl Context {
@@ -53,7 +62,7 @@ impl Context {
     pub(super) fn with_ctes(&self, ctes: Vec<CteDecl>) -> Context {
         Context {
             ctes,
-            outer: self.outer.clone(),
+            ..self.clone()
         }
     }
 
@@ -77,6 +86,14 @@ impl Context {
     /// outside any subquery in the body.
     pub(super) fn with_lambda(&self, params: impl IntoIterator<Item = Ident>) -> Context {
         self.pushing(Level::Lambda(params.into_iter().collect()))
+    }
+
+    /// A child context marked as binding a conflict action whose `EXCLUDED`
+    /// pseudo-relation exposes `columns`.
+    pub(super) fn with_excluded(&self, columns: Vec<Ident>) -> Context {
+        let mut child = self.clone();
+        child.excluded_columns = columns;
+        child
     }
 
     fn pushing(&self, level: Level) -> Context {

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -1043,21 +1043,41 @@ impl<'a> Binder<'a> {
         }
     }
 
-    /// The ORDER BY key expressions (a trailing `query.order_by`).
+    /// The ORDER BY key expressions (a trailing `query.order_by`), plus the
+    /// ClickHouse `INTERPOLATE (col AS expr, …)` fill expressions — clause
+    /// reads over the same scope (the `col` designator names an output like
+    /// an alias target, so it is not itself an occurrence).
     pub(super) fn order_by_keys(&mut self, order_by: &OrderBy, scope: &Scope) -> Vec<Expr> {
-        let OrderByKind::Expressions(exprs) = &order_by.kind else {
-            return Vec::new();
+        let mut keys = match &order_by.kind {
+            OrderByKind::Expressions(exprs) => self.order_by_expr_keys(exprs, scope),
+            OrderByKind::All(_) => Vec::new(),
         };
-        self.order_by_expr_keys(exprs, scope)
+        for ie in order_by
+            .interpolate
+            .iter()
+            .flat_map(|i| i.exprs.iter().flatten())
+        {
+            if let Some(e) = &ie.expr {
+                keys.push(self.bind_expr(e, scope));
+            }
+        }
+        keys
     }
 
     /// Bind a list of order-by expressions (`query.order_by` members or a
-    /// `SELECT … SORT BY` list) as clause reads.
+    /// `SELECT … SORT BY` list) as clause reads, including each key's
+    /// ClickHouse `WITH FILL FROM … TO … STEP …` bound expressions.
     pub(super) fn order_by_expr_keys(&mut self, exprs: &[OrderByExpr], scope: &Scope) -> Vec<Expr> {
-        exprs
-            .iter()
-            .map(|e| self.bind_clause_key(&e.expr, scope))
-            .collect()
+        let mut keys = Vec::new();
+        for e in exprs {
+            keys.push(self.bind_clause_key(&e.expr, scope));
+            if let Some(wf) = &e.with_fill {
+                for bound in [&wf.from, &wf.to, &wf.step].into_iter().flatten() {
+                    keys.push(self.bind_expr(bound, scope));
+                }
+            }
+        }
+        keys
     }
 
     /// Summarise the projection outputs for clause-alias resolution. An output

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -1074,17 +1074,23 @@ impl<'a> Binder<'a> {
         exprs
             .iter()
             .flat_map(|ne| {
-                // An identity output re-reads a real base column (so a later
-                // clause-alias / pipe reference to it reads that column). Only a
-                // `Base` column qualifies: a `Derived` passthrough (a pipe-
-                // carried alias, a derived-table column) traces back through the
-                // projection chain, not to a base table — marking it identity
-                // would let a later stage fall through to the base relation and
-                // fabricate a phantom read. A fan's names are always introduced
-                // aliases (never the column itself), so never identity.
+                // An identity output re-reads its column (so a later
+                // clause-alias / pipe reference to it reads that column
+                // again, occurrence-based). Any *physical* occurrence
+                // qualifies — `Base`, and equally an `Ambiguous` /
+                // `Unresolved` one, whose clause re-reference re-resolves to
+                // the same contested / unresolved read (`SELECT a FROM t1,
+                // t2 GROUP BY a` counts two ambiguous occurrences, like the
+                // single-table form counts two base reads). A `Derived`
+                // passthrough (a pipe-carried alias, a derived-table column)
+                // traces back through the projection chain, not to a base
+                // table — marking it identity would let a later stage fall
+                // through to the base relation and fabricate a phantom read.
+                // A fan's names are always introduced aliases (never the
+                // column itself), so never identity.
                 let identity = match (&ne.names, &ne.expr) {
                     (OutputNames::Single(Some(name)), Expr::Column(c)) => {
-                        matches!(c.binding, Binding::Base { .. })
+                        !matches!(c.binding, Binding::Derived | Binding::Local)
                             && self.eq(self.style.casing.column, name, &c.name)
                     }
                     _ => false,

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -14,6 +14,20 @@ impl<'a> Binder<'a> {
         item: &SelectItem,
         scope: &Scope,
     ) -> (Vec<NamedExpr>, bool) {
+        self.bind_select_item_inner(item, scope, true)
+    }
+
+    /// [`bind_select_item`](Self::bind_select_item) with wildcard expansion
+    /// switched off (`expand = false`) — for a projection under a
+    /// select-level `EXCLUDE`, which filters the projected set after the
+    /// items, so an expansion would read the excluded columns. The wildcard
+    /// then takes its suppression path (flagged, `REPLACE` outputs kept).
+    pub(super) fn bind_select_item_inner(
+        &mut self,
+        item: &SelectItem,
+        scope: &Scope,
+        expand: bool,
+    ) -> (Vec<NamedExpr>, bool) {
         match item {
             SelectItem::UnnamedExpr(expr) => (
                 vec![NamedExpr {
@@ -53,14 +67,16 @@ impl<'a> Binder<'a> {
             // exactly a standalone `expr AS col`; only the output position is
             // best-effort, since the wildcard's own columns aren't enumerated).
             SelectItem::Wildcard(options) => {
-                if let Some(items) = self.expand_wildcard(None, options, scope) {
-                    return (items, true);
+                if expand {
+                    if let Some(items) = self.expand_wildcard(None, options, scope) {
+                        return (items, true);
+                    }
                 }
                 self.record_wildcard_suppressed("wildcard `*`", options.wildcard_token.0.span);
                 (self.replace_outputs(options, scope), false)
             }
             SelectItem::QualifiedWildcard(kind, options) => {
-                if let SelectItemQualifiedWildcardKind::ObjectName(name) = kind {
+                if let (true, SelectItemQualifiedWildcardKind::ObjectName(name)) = (expand, kind) {
                     if let Some(items) = self.expand_wildcard(Some(name), options, scope) {
                         return (items, true);
                     }

--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -928,9 +928,11 @@ impl<'a> Binder<'a> {
     }
 
     /// Filter-position reads from a SELECT's auxiliary clauses (`DISTINCT ON`
-    /// keys, `TOP n`, Hive `LATERAL VIEW`, `PREWHERE`, `CONNECT BY` / `START
-    /// WITH`, `CLUSTER BY` / `DISTRIBUTE BY`, named `WINDOW` specs), resolved
-    /// against the FROM scope. None feed values. `QUALIFY` is *not* here — it
+    /// keys, `TOP n`, `PREWHERE`, `CONNECT BY` / `START WITH`, `CLUSTER BY` /
+    /// `DISTRIBUTE BY`, named `WINDOW` specs), resolved against the FROM
+    /// scope. None feed values. Hive `LATERAL VIEW` is *not* here — it is a
+    /// value-feeding lateral table function, joined into the FROM by
+    /// [`bind_select`](Self::bind_select). `QUALIFY` is *not* here — it
     /// filters on window / projection outputs (post-projection), so it binds
     /// against the output-aware scope in [`bind_select`](Self::bind_select).
     pub(super) fn select_clause_reads(&mut self, select: &Select, scope: &Scope) -> Vec<Expr> {
@@ -942,9 +944,6 @@ impl<'a> Binder<'a> {
             if let Some(TopQuantity::Expr(expr)) = &top.quantity {
                 reads.push(self.bind_expr(expr, scope));
             }
-        }
-        for lateral_view in &select.lateral_views {
-            reads.push(self.bind_expr(&lateral_view.lateral_view, scope));
         }
         reads.extend(select.prewhere.iter().map(|e| self.bind_expr(e, scope)));
         for connect_by in &select.connect_by {

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -399,6 +399,24 @@ impl<'a> Binder<'a> {
         (exprs, complete)
     }
 
+    /// [`bind_output_items`](Self::bind_output_items) with wildcard expansion
+    /// suppressed — see
+    /// [`bind_select_item_inner`](Self::bind_select_item_inner).
+    pub(super) fn bind_output_items_unexpanded(
+        &mut self,
+        items: &[SelectItem],
+        scope: &Scope,
+    ) -> (Vec<NamedExpr>, bool) {
+        let mut exprs = Vec::new();
+        let mut complete = true;
+        for item in items {
+            let (bound, determinate) = self.bind_select_item_inner(item, scope, false);
+            complete &= determinate;
+            exprs.extend(bound);
+        }
+        (exprs, complete)
+    }
+
     /// Build an output-producing pipe `Projection`: the positional passthrough
     /// of the `base` outputs plus the `new` value columns. The passthrough
     /// keeps each base `OutputCol` verbatim (name *and* identity — so a later
@@ -650,6 +668,14 @@ impl<'a> Binder<'a> {
                     (Vec::new(), false)
                 }
             }
+        } else if select.exclude.is_some() {
+            // Redshift's select-level `EXCLUDE` filters the projected set
+            // *after* the items — expanding a wildcard while ignoring it
+            // would read the excluded columns, so expansion is suppressed
+            // and flagged (all-or-nothing, exactly like the per-wildcard
+            // `EXCLUDE` modifier); written items bind as usual.
+            let (exprs, _) = self.bind_output_items_unexpanded(&select.projection, &scope);
+            (exprs, false)
         } else {
             self.bind_output_items(&select.projection, &scope)
         };

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -576,7 +576,44 @@ impl<'a> Binder<'a> {
     /// outputs (clause-alias visibility) — a resolution-scope rule, independent
     /// of tree position.
     pub(super) fn bind_select(&mut self, select: &Select) -> (LogicalPlan, Scope) {
-        let (from, scope) = self.bind_from(&select.from);
+        let (mut from, mut scope) = self.bind_from(&select.from);
+        // Hive `LATERAL VIEW explode(arr) v [AS c, …]`: each view is a
+        // lateral table function joined onto the FROM. Its argument reads
+        // against the relations so far (the FROM plus the earlier views),
+        // and it joins in as a table-function relation — with a declared
+        // column-alias list, a *closed* one (`Derived`), so a reference to
+        // a generated column resolves to the view and traces to the
+        // function's arguments at function granularity, instead of falling
+        // to a base relation as a phantom read. (With several views, a
+        // bare generated column still resolves to the one view listing it,
+        // but the name-keyed trace reaches every view's arguments — the
+        // usual function-granularity coarseness.)
+        for lv in &select.lateral_views {
+            let args = vec![self.bind_expr(&lv.lateral_view, &scope)];
+            let alias = lv
+                .lateral_view_name
+                .0
+                .last()
+                .and_then(|p| p.as_ident().cloned());
+            let node = LogicalPlan::TableFunction(TableFunction {
+                alias: alias.clone(),
+                input: Box::new(LogicalPlan::Empty),
+                args,
+            });
+            let relation = if lv.lateral_col_alias.is_empty() {
+                Relation::TableFunction { alias }
+            } else {
+                Relation::Derived {
+                    alias,
+                    columns: Exposed {
+                        slots: lv.lateral_col_alias.iter().cloned().map(Some).collect(),
+                        complete: true,
+                    },
+                }
+            };
+            scope.relations.push(relation);
+            from = combine(from, node);
+        }
         // WHERE + the WHERE-family auxiliary clauses (DISTINCT ON / TOP /
         // LATERAL VIEW / PREWHERE / CONNECT BY / CLUSTER BY / named WINDOW)
         // filter rows before grouping — a filter over the FROM (no output

--- a/sql-insight/src/resolver/binder/resolve.rs
+++ b/sql-insight/src/resolver/binder/resolve.rs
@@ -62,6 +62,29 @@ impl<'a> Binder<'a> {
                     })
             })
             .unwrap_or(Binding::Unresolved);
+        // Conflict-action contest (PostgreSQL parity): while binding an
+        // `ON CONFLICT DO UPDATE` action, an unqualified reference to an
+        // `EXCLUDED` column is contested between the existing target row and
+        // `EXCLUDED` — PG rejects it as ambiguous — so a `Derived` claim
+        // (the `EXCLUDED` exposure winning over the catalog-free target)
+        // demotes to `Ambiguous`. As a resolution rule it reaches a
+        // correlated reference inside a subquery of the action too (the
+        // post-pass it replaces stopped at the subquery boundary, and the
+        // reference vanished from the surfaces entirely). Best-effort limit:
+        // a subquery's *own* derived relation exposing the same contested
+        // name demotes as well.
+        let binding = if parts.len() == 1
+            && matches!(binding, Binding::Derived)
+            && self
+                .context
+                .excluded_columns
+                .iter()
+                .any(|c| self.eq(self.style.casing.column, c, name))
+        {
+            Binding::Ambiguous
+        } else {
+            binding
+        };
         BoundColumn {
             qualifier: (parts.len() >= 2).then(|| parts[parts.len() - 2].clone()),
             name: name.clone(),

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -233,6 +233,11 @@ impl<'a> Binder<'a> {
                 .iter()
                 .filter_map(|n| n.0.last().and_then(|p| p.as_ident().cloned()))
                 .collect()
+        } else if !insert.after_columns.is_empty() {
+            // The Hive placement: `INSERT INTO t PARTITION (…) (a, b)` puts
+            // the column list *after* the partition clause — the same
+            // explicit list, previously dropped as if none were written.
+            insert.after_columns.clone()
         } else {
             view_columns
         };

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -949,11 +949,6 @@ impl<'a> Binder<'a> {
                                 .filter_map(|n| n.0.last().and_then(|p| p.as_ident().cloned()))
                                 .collect();
                             let catalog_cols = self.catalog_columns(&target);
-                            let columns = if explicit.is_empty() {
-                                catalog_cols.clone()
-                            } else {
-                                explicit
-                            };
                             // A MERGE INSERT is a single VALUES row. Each row is
                             // now a `Parens<Vec<Expr>>`; flatten through its
                             // inner expressions (via `Deref`).
@@ -963,6 +958,17 @@ impl<'a> Binder<'a> {
                                 .flat_map(|row| row.iter())
                                 .map(|e| self.bind_expr(e, &scope))
                                 .collect();
+                            let columns = if explicit.is_empty() {
+                                // The catalog fill truncates to the row's
+                                // arity (mirroring `bind_insert`): a column
+                                // no value reaches is not written — filling
+                                // all catalog columns fabricated writes for
+                                // the surplus (the overflow direction is
+                                // still flagged below).
+                                catalog_cols.iter().take(row.len()).cloned().collect()
+                            } else {
+                                explicit
+                            };
                             // Column-list-less and no catalog to fill the target
                             // columns: the values can't be paired (see `bind_insert`).
                             // A MERGE INSERT VALUES has no wildcard, so the cause

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -1657,8 +1657,10 @@ impl<'a> Binder<'a> {
 
     /// `ALTER TABLE t <ops>`: the altered table is a write target; each
     /// column-naming operation contributes its column(s) as writes (RENAME /
-    /// CHANGE surface both names). Schema-level ops name no columns. No reads
-    /// or lineage — ALTER restructures, it doesn't move row data.
+    /// CHANGE surface both names), and a `RENAME TO` surfaces the new table
+    /// name as a write beside the old (the table-level mirror of that rule).
+    /// Schema-level ops name no columns. No reads or lineage — ALTER
+    /// restructures, it doesn't move row data.
     pub(super) fn bind_alter_table(&mut self, alter: &SqlAlterTable) -> LogicalPlan {
         let Some(written) = self.table_ref(&alter.name) else {
             return LogicalPlan::Empty;
@@ -1669,12 +1671,25 @@ impl<'a> Binder<'a> {
             .iter()
             .flat_map(alter_table_op_target_columns)
             .collect();
+        let rename_to = alter
+            .operations
+            .iter()
+            .find_map(|op| match op {
+                AlterTableOperation::RenameTable { table_name } => Some(match table_name {
+                    sqlparser::ast::RenameTableNameKind::As(name)
+                    | sqlparser::ast::RenameTableNameKind::To(name) => name,
+                }),
+                _ => None,
+            })
+            .and_then(|name| self.table_ref(name))
+            .map(|written| self.table_write(&written));
         LogicalPlan::AlterTable(AlterTable {
             target: TableWrite {
                 reference: m.table,
                 resolution: m.resolution,
             },
             columns,
+            rename_to,
         })
     }
 

--- a/sql-insight/src/resolver/binder/statement.rs
+++ b/sql-insight/src/resolver/binder/statement.rs
@@ -577,34 +577,30 @@ impl<'a> Binder<'a> {
             // `OnInsert` is non-exhaustive; an unmodelled action is a no-op.
             _ => return (Vec::new(), Vec::new()),
         };
-        // A conflict-action SET always targets the insert target's own columns
-        // (no other writable relations, hence the empty candidate set).
-        let mut bound: Vec<Assignment> = assignments
-            .iter()
-            .flat_map(|a| self.bind_assignment(a, &scope, target, &[]))
-            .collect();
-        let mut predicate: Vec<Expr> = selection
-            .map(|s| self.bind_expr(s, &scope))
-            .into_iter()
-            .collect();
-        // PostgreSQL parity: an *unqualified* reference in the conflict action
-        // is contested between the existing target row and `EXCLUDED` — PG 17 / 18
-        // reject it (`column reference "b" is ambiguous`; SQLite instead reads
-        // the target), so no single attribution is right and it surfaces
-        // `Ambiguous`, matching what the catalog-aware bind already produces
-        // (target + EXCLUDED are then two confirming witnesses). The generic
-        // scope resolution instead lets the `EXCLUDED` exposure win as the sole
-        // witness over a catalog-free (`Unknown`) target — demote exactly those
-        // bindings: in this scope an unqualified `Derived` can only be
-        // `EXCLUDED` (the sole derived relation). Qualified references
-        // (`EXCLUDED.b` / `t.b`) keep their binding.
-        for a in &mut bound {
-            demote_unqualified_excluded(&mut a.value);
-        }
-        for p in &mut predicate {
-            demote_unqualified_excluded(p);
-        }
-        (bound, predicate)
+        // The action binds under the conflict-contest rule
+        // ([`Context::excluded_columns`]): an unqualified reference to an
+        // `EXCLUDED` column is contested between the existing target row and
+        // `EXCLUDED` — PG 17 / 18 reject it (`column reference "b" is
+        // ambiguous`; SQLite instead reads the target) — so resolution
+        // demotes it to `Ambiguous`, including a correlated reference inside
+        // a subquery of the action (the old expression post-pass stopped at
+        // the subquery boundary, and the reference vanished from the
+        // surfaces). Qualified references (`EXCLUDED.b` / `t.b`) keep their
+        // binding. A conflict-action SET always targets the insert target's
+        // own columns (no other writable relations, hence the empty
+        // candidate set).
+        let child = self.context.with_excluded(columns.to_vec());
+        self.in_scope(child, |b| {
+            let bound: Vec<Assignment> = assignments
+                .iter()
+                .flat_map(|a| b.bind_assignment(a, &scope, target, &[]))
+                .collect();
+            let predicate: Vec<Expr> = selection
+                .map(|s| b.bind_expr(s, &scope))
+                .into_iter()
+                .collect();
+            (bound, predicate)
+        })
     }
 
     /// `UPDATE target SET col = expr [FROM src] WHERE pred`: the target is in
@@ -1784,53 +1780,6 @@ fn view_target_columns(projection: &[SelectItem]) -> Vec<Ident> {
         }
     }
     columns
-}
-
-/// Demote an unqualified conflict-scope reference that resolved to `EXCLUDED`
-/// (an unqualified `Binding::Derived` — `EXCLUDED` is the scope's sole derived
-/// relation) to [`Binding::Ambiguous`] — see the call in
-/// [`Binder::bind_conflict`] for the engine-verified rationale. The walk stays
-/// on the expression's **own** operands: a nested subquery owns its own scope,
-/// so its bindings are left alone. The `Expr` match is exhaustive so a new
-/// variant forces a decision here.
-fn demote_unqualified_excluded(expr: &mut Expr) {
-    match expr {
-        Expr::Column(c) => {
-            if c.qualifier.is_none() && matches!(c.binding, Binding::Derived) {
-                c.binding = Binding::Ambiguous;
-            }
-        }
-        Expr::Call { args } => args.iter_mut().for_each(demote_unqualified_excluded),
-        Expr::Case {
-            when,
-            then,
-            else_result,
-        } => {
-            when.iter_mut()
-                .chain(then.iter_mut())
-                .for_each(demote_unqualified_excluded);
-            if let Some(e) = else_result {
-                demote_unqualified_excluded(e);
-            }
-        }
-        Expr::Window {
-            arg,
-            partition,
-            order,
-        } => {
-            demote_unqualified_excluded(arg);
-            partition
-                .iter_mut()
-                .chain(order.iter_mut())
-                .for_each(demote_unqualified_excluded);
-        }
-        Expr::InSubquery { expr, .. } => demote_unqualified_excluded(expr),
-        Expr::Filter(exprs) => exprs.iter_mut().for_each(demote_unqualified_excluded),
-        // A merge fan-in can't arise (no USING join in a conflict scope) and
-        // neither can an expanded slot (no projection); a subquery's plan owns
-        // its own scope.
-        Expr::Fanin(_) | Expr::DerivedSlot { .. } | Expr::Subquery { .. } | Expr::Exists(_) => {}
-    }
 }
 
 /// The target table of a query's leading `SELECT … INTO t`, if any. `INTO`

--- a/sql-insight/src/resolver/logical_plan.rs
+++ b/sql-insight/src/resolver/logical_plan.rs
@@ -379,6 +379,10 @@ pub(crate) struct CreateView {
 pub(crate) struct AlterTable {
     pub(crate) target: TableWrite,
     pub(crate) columns: Vec<Ident>,
+    /// `RENAME TO`'s new table name, surfaced as a write alongside the
+    /// old one — the table-level mirror of RENAME COLUMN surfacing both
+    /// column names.
+    pub(crate) rename_to: Option<TableWrite>,
 }
 
 /// `DROP TABLE/VIEW` / `TRUNCATE`: names relations as write targets; no

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -284,13 +284,24 @@ fn origins_of_slot<'a>(
                 })
                 .unwrap_or_default()
         }
-        // A table function reached here is always a walked-past join side:
-        // expansion never mints a slot over one (its shape is unknown), and a
-        // qualifier naming both it and the slot's own derived relation would
-        // have failed the unique-match guard at expansion. Nothing to claim.
+        // A table function claims a slot minted against *its* relation — a
+        // Hive LATERAL VIEW with a column-alias list exposes a closed
+        // Derived relation over a `TableFunction` node, so a wildcard can
+        // enumerate its slots — tracing to the function's arguments at
+        // function granularity, exactly like the named trace's arm. The
+        // slot is always qualified by the view alias (the relation is
+        // aliased by construction); an unqualified slot is some other
+        // producer's, and a bare (alias-less) function's shape is unknown
+        // (expansion never mints over it), so both claim nothing.
+        LogicalPlan::TableFunction(tf) => match (&tf.alias, qualifier) {
+            (Some(alias), Some(q)) if context.eq_alias(q, alias) => {
+                transform(table_function_output_origins(tf, context))
+            }
+            _ => Vec::new(),
+        },
         // Not positional producers otherwise: a raw scan on a walked-past
         // join side, and DML / DDL roots.
-        LogicalPlan::TableFunction(_) | LogicalPlan::Scan(_) | LogicalPlan::Empty => Vec::new(),
+        LogicalPlan::Scan(_) | LogicalPlan::Empty => Vec::new(),
         LogicalPlan::Insert(_)
         | LogicalPlan::Update(_)
         | LogicalPlan::Delete(_)

--- a/sql-insight/src/resolver/tables.rs
+++ b/sql-insight/src/resolver/tables.rs
@@ -129,7 +129,11 @@ pub(super) fn write_root_tables(root: &LogicalPlan) -> Vec<TableWrite> {
         LogicalPlan::Delete(d) => d.targets.clone(),
         LogicalPlan::CreateTableAs(c) => vec![c.target.clone()],
         LogicalPlan::CreateView(c) => vec![c.target.clone()],
-        LogicalPlan::AlterTable(a) => vec![a.target.clone()],
+        LogicalPlan::AlterTable(a) => {
+            let mut w = vec![a.target.clone()];
+            w.extend(a.rename_to.clone());
+            w
+        }
         LogicalPlan::Merge(m) => vec![m.target.clone()],
         // DROP / TRUNCATE name their relations directly as write targets.
         LogicalPlan::Drop(d) => d.targets.clone(),

--- a/sql-insight/tests/column_operation_extractor/arm_coverage.rs
+++ b/sql-insight/tests/column_operation_extractor/arm_coverage.rs
@@ -1388,9 +1388,9 @@ mod relation_arm_coverage {
 
     #[test]
     fn lateral_view() {
-        // `select.lateral_views` walks each `lateral_view` expression
-        // (here `EXPLODE(t.arr)`); the `v` alias is not bound as a real
-        // table, so we read against `t` to keep the assertion stable.
+        // A LATERAL VIEW joins in as a table function: its argument
+        // (`EXPLODE(t.arr)`) reads, its alias is a synthetic relation (not
+        // a real table), and its generated column resolves to the view.
         assert_unordered_eq!(
             reads("SELECT t.a FROM t LATERAL VIEW EXPLODE(t.arr) v AS x"),
             vec![c("t", "a"), c("t", "arr")]

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -752,6 +752,39 @@ mod on_conflict {
     }
 
     #[test]
+    fn pg_on_conflict_contest_reaches_into_a_subquery() {
+        // The contest is a resolution rule, not an expression post-pass, so
+        // a *correlated* reference inside a subquery of the action demotes
+        // the same way — it used to keep the EXCLUDED claim and vanish from
+        // the surfaces entirely. A reference the subquery's own FROM
+        // resolves (`s.a` below) is untouched.
+        assert_column_ops_with_dialect(
+            "INSERT INTO t (a) VALUES (1) \
+             ON CONFLICT (a) DO UPDATE SET a = (SELECT a + 1)",
+            &PostgreSqlDialect {},
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![ambiguous("a")],
+                writes: vec![write("t", "a"), write("t", "a")],
+                lineage: vec![transformation(ambiguous("a"), relation("t", "a"))],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops_with_dialect(
+            "INSERT INTO t (a) VALUES (1) \
+             ON CONFLICT (a) DO UPDATE SET a = (SELECT s.a FROM s)",
+            &PostgreSqlDialect {},
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s", "a")],
+                writes: vec![write("t", "a"), write("t", "a")],
+                lineage: vec![transformation(col("s", "a"), relation("t", "a"))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn pg_on_conflict_excluded_mapping_is_gated_by_an_unexpanded_wildcard() {
         // The source projection kept an unexpanded `*`, so its positions are
         // indeterminate — the `EXCLUDED.a` positional mapping must yield no

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1043,6 +1043,24 @@ mod output_alias_visibility {
     }
 
     #[test]
+    fn ambiguous_identity_output_still_counts_its_clause_occurrence() {
+        // `a` is contested between t1 and t2, but the GROUP BY occurrence is
+        // still a written physical reference — it re-resolves to the same
+        // `Ambiguous` read (two occurrences, like the single-table form
+        // counts two base reads; it used to vanish, undercounting).
+        assert_column_ops(
+            "SELECT a FROM t1, t2 GROUP BY a",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![ambiguous("a"), ambiguous("a")],
+                writes: vec![],
+                lineage: vec![passthrough(ambiguous("a"), out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn group_by_ordinal_of_introduced_alias_is_suppressed() {
         // `GROUP BY 1` here is `a + b AS x` (an introduced alias) — like
         // `GROUP BY x`, it binds Derived and adds no read; the dependency on

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -391,7 +391,6 @@ mod reads {
 // kept) and the lineage they produce.
 mod reads_by_clause {
     use super::*;
-    use sql_insight::sqlparser::dialect::ClickHouseDialect;
 
     #[test]
     fn same_column_in_projection_and_where_is_two_reads() {
@@ -1032,7 +1031,7 @@ mod output_alias_visibility {
         // dropped entirely); the interpolate *target* designator names an
         // output, not an occurrence.
         assert_column_ops_with_dialect(
-            &ClickHouseDialect {},
+            &sql_insight::sqlparser::dialect::ClickHouseDialect {},
             "SELECT a FROM t ORDER BY a WITH FILL FROM t.lo TO t.hi STEP 1 \
              INTERPOLATE (a AS a + t.b)",
             ColumnOperation {

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1574,3 +1574,58 @@ mod pipe_join {
         );
     }
 }
+
+mod lateral_view {
+    //! Hive `LATERAL VIEW`: a lateral table function joined onto the FROM.
+    //! The declared column aliases are the view's closed column list, so a
+    //! generated column resolves to the view — traced to the function's
+    //! arguments at function granularity — never to a base relation as a
+    //! phantom read.
+    use super::*;
+    use sql_insight::sqlparser::dialect::HiveDialect;
+
+    #[test]
+    fn generated_column_resolves_to_the_view_not_the_base_table() {
+        // `c` is explode's output: no `t.c` read (it used to be a phantom),
+        // a Transformation from the argument instead — for the bare, the
+        // qualified, and the filter-position reference alike.
+        assert_column_ops_with_dialect(
+            &HiveDialect {},
+            "SELECT x.c, t.a FROM t LATERAL VIEW explode(arr) x AS c WHERE c > 0",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "arr")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("t", "arr"), out("c", 0)),
+                    passthrough(col("t", "a"), out("a", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn several_views_fan_at_function_granularity() {
+        // Each generated column resolves to the view listing it, but the
+        // name-keyed trace reaches every view's arguments — the usual
+        // function-granularity coarseness, fanned rather than dropped.
+        assert_column_ops_with_dialect(
+            &HiveDialect {},
+            "SELECT k, v FROM t LATERAL VIEW explode(a) x AS k \
+             LATERAL VIEW explode(b) y AS v",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b")],
+                writes: vec![],
+                lineage: vec![
+                    transformation(col("t", "a"), out("k", 0)),
+                    transformation(col("t", "a"), out("v", 1)),
+                    transformation(col("t", "b"), out("k", 0)),
+                    transformation(col("t", "b"), out("v", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+}

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -391,6 +391,7 @@ mod reads {
 // kept) and the lineage they produce.
 mod reads_by_clause {
     use super::*;
+    use sql_insight::sqlparser::dialect::ClickHouseDialect;
 
     #[test]
     fn same_column_in_projection_and_where_is_two_reads() {
@@ -1017,6 +1018,33 @@ mod output_alias_visibility {
             ColumnOperation {
                 statement_kind: StatementKind::Select,
                 reads: vec![read("t", "a"), read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn with_fill_and_interpolate_expressions_read() {
+        // ClickHouse `WITH FILL FROM … TO … STEP` bounds and `INTERPOLATE
+        // (col AS expr)` fill expressions are clause reads (they used to be
+        // dropped entirely); the interpolate *target* designator names an
+        // output, not an occurrence.
+        assert_column_ops_with_dialect(
+            &ClickHouseDialect {},
+            "SELECT a FROM t ORDER BY a WITH FILL FROM t.lo TO t.hi STEP 1 \
+             INTERPOLATE (a AS a + t.b)",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read("t", "a"),
+                    read("t", "a"),
+                    read("t", "lo"),
+                    read("t", "hi"),
+                    read("t", "a"),
+                    read("t", "b"),
+                ],
                 writes: vec![],
                 lineage: vec![passthrough(col("t", "a"), out("a", 0))],
                 diagnostics: vec![],

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1025,6 +1025,24 @@ mod output_alias_visibility {
     }
 
     #[test]
+    fn ordinal_over_incomplete_outputs_binds_as_a_literal() {
+        // The unexpanded `*` hides slots, so position 1 is *not* the written
+        // `a` — the ordinal must not bind to it (it used to, minting a
+        // phantom second `t.a` read). It falls back to the literal, which
+        // reads nothing; expansion (a catalog) re-enables the ordinal.
+        assert_column_ops(
+            "SELECT *, a FROM t ORDER BY 1",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
+            },
+        );
+    }
+
+    #[test]
     fn group_by_ordinal_of_introduced_alias_is_suppressed() {
         // `GROUP BY 1` here is `a + b AS x` (an introduced alias) — like
         // `GROUP BY x`, it binds Derived and adds no read; the dependency on

--- a/sql-insight/tests/column_operation_extractor/resolution.rs
+++ b/sql-insight/tests/column_operation_extractor/resolution.rs
@@ -461,6 +461,36 @@ mod catalog_strict {
     }
 
     #[test]
+    fn catalog_merge_insert_fill_truncates_to_the_row_arity() {
+        // A narrower VALUES row fills only the leading catalog columns
+        // (mirroring the plain-INSERT fill): `b` receives no value, so it
+        // is not written — filling all catalog columns used to fabricate a
+        // `t.b` write. The undersupply is a shape the arity diagnostic
+        // deliberately tolerates for a column-less fill (overflow flags).
+        let catalog = TestCatalog::default().with("t", vec!["id", "a", "b"]);
+        assert_column_ops_with_catalog(
+            "MERGE INTO t USING s ON t.id = s.id \
+             WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.a)",
+            &catalog,
+            ColumnOperation {
+                statement_kind: StatementKind::Merge,
+                reads: vec![
+                    read_confirmed("t", "id"),
+                    read("s", "id"),
+                    read("s", "id"),
+                    read("s", "a"),
+                ],
+                writes: vec![filled_write("t", "id"), filled_write("t", "a")],
+                lineage: vec![
+                    passthrough(col("s", "id"), filled_relation("t", "id")),
+                    passthrough(col("s", "a"), filled_relation("t", "a")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn catalog_using_merge_column_fans_in_cataloged() {
         // A USING merge column fans in to both joined tables; with a
         // catalog confirming `id` on each, both sides resolve Cataloged.

--- a/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
+++ b/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
@@ -115,6 +115,36 @@ mod catalog_tables {
     }
 
     #[test]
+    fn select_level_exclude_suppresses_expansion() {
+        // Redshift's select-level `EXCLUDE` filters the projected set after
+        // the items — expanding the `*` while ignoring it fabricated a read
+        // of the excluded column (`c3`). The wildcard stays suppressed and
+        // flagged, like the per-wildcard `EXCLUDE` modifier; the written
+        // `c1` binds as usual.
+        let catalog = TestCatalog::default().with("t", vec!["c1", "c2", "c3"]);
+        let options = ExtractorOptions::new().with_catalog(&catalog.catalog);
+        let op = extract_column_operations_with_options(
+            &sql_insight::sqlparser::dialect::RedshiftSqlDialect {},
+            "SELECT *, c1 EXCLUDE c3 FROM t",
+            options,
+        )
+        .unwrap()
+        .remove(0)
+        .unwrap();
+        let names: Vec<&str> = op
+            .reads
+            .iter()
+            .map(|r| r.reference.name.value.as_str())
+            .collect();
+        assert_eq!(names, ["c1"]);
+        assert_eq!(
+            op.diagnostics.len(),
+            1,
+            "one WildcardSuppressed flag expected"
+        );
+    }
+
+    #[test]
     fn expanded_columns_sort_at_the_wildcard_in_schema_order() {
         // Surfaces are source-ordered; every expanded column carries the `*`
         // token's span, so the whole block sorts at the wildcard — in schema

--- a/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
+++ b/sql-insight/tests/column_operation_extractor/wildcard_expansion.rs
@@ -115,6 +115,39 @@ mod catalog_tables {
     }
 
     #[test]
+    fn wildcard_expands_over_a_lateral_view_and_traces_its_slot() {
+        // The scope is `t` plus the view's closed Derived relation, so the
+        // `*` expands to (a, arr, c); the view's slot traces to the
+        // function's argument at function granularity (`arr -> c`, a
+        // Transformation) — the slot used to be edge-less.
+        let catalog = TestCatalog::default().with("t", vec!["a", "arr"]);
+        let options = ExtractorOptions::new().with_catalog(&catalog.catalog);
+        let op = extract_column_operations_with_options(
+            &sql_insight::sqlparser::dialect::HiveDialect {},
+            "SELECT * FROM t LATERAL VIEW explode(arr) x AS c",
+            options,
+        )
+        .unwrap()
+        .remove(0)
+        .unwrap();
+        let edges: Vec<(&str, String)> = op
+            .lineage
+            .iter()
+            .map(|e| {
+                (
+                    e.source.reference.name.value.as_str(),
+                    format!("{:?}", e.target),
+                )
+            })
+            .collect();
+        assert_eq!(edges.len(), 3, "a, arr, and the view's c: {edges:#?}");
+        assert!(
+            edges[2].0 == "arr" && edges[2].1.contains("\"c\""),
+            "the view slot traces to the argument: {edges:#?}"
+        );
+    }
+
+    #[test]
     fn select_level_exclude_suppresses_expansion() {
         // Redshift's select-level `EXCLUDE` filters the projected set after
         // the items — expanding the `*` while ignoring it fabricated a read

--- a/sql-insight/tests/column_operation_extractor/writes_deletes.rs
+++ b/sql-insight/tests/column_operation_extractor/writes_deletes.rs
@@ -19,6 +19,27 @@ mod writes {
     }
 
     #[test]
+    fn hive_partition_placed_column_list_pairs_like_the_normal_one() {
+        // Hive puts the explicit column list *after* the PARTITION clause
+        // (`Insert::after_columns`); it used to be dropped as if no list
+        // were written, losing the writes and the positional pairing.
+        assert_column_ops_with_dialect(
+            &sql_insight::sqlparser::dialect::HiveDialect {},
+            "INSERT INTO TABLE t PARTITION (p = 1) (a, b) SELECT x, y FROM s",
+            ColumnOperation {
+                statement_kind: StatementKind::Insert,
+                reads: vec![read("s", "x"), read("s", "y")],
+                writes: vec![write("t", "a"), write("t", "b")],
+                lineage: vec![
+                    passthrough(col("s", "x"), relation("t", "a")),
+                    passthrough(col("s", "y"), relation("t", "b")),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn insert_select_records_target_writes_and_qualified_source_reads() {
         assert_column_ops(
             "INSERT INTO t1 (a) SELECT t2.b FROM t2",

--- a/sql-insight/tests/crud_table_extractor.rs
+++ b/sql-insight/tests/crud_table_extractor.rs
@@ -577,6 +577,40 @@ mod insert_statement {
     }
 
     #[test]
+    fn test_sqlite_replace_buckets_target_as_create_and_delete() {
+        use sql_insight::sqlparser::dialect::SQLiteDialect;
+        // SQLite's REPLACE deletes the conflicting rows before inserting,
+        // like MySQL's — but its `REPLACE INTO` / `INSERT OR REPLACE` parse
+        // to the `or` conflict clause, not the `replace_into` flag. A
+        // non-replacing `OR` clause (IGNORE) stays create-only.
+        for sql in [
+            "REPLACE INTO t1 (a) VALUES (1)",
+            "INSERT OR REPLACE INTO t1 (a) VALUES (1)",
+        ] {
+            let expected = vec![Ok(CrudTables {
+                create_tables: vec![cwrite(table("t1"))],
+                read_tables: vec![],
+                update_tables: vec![],
+                delete_tables: vec![cwrite(table("t1"))],
+                diagnostics: vec![],
+            })];
+            assert_crud_table_extraction(sql, expected, vec![Box::new(SQLiteDialect {})]);
+        }
+        let expected = vec![Ok(CrudTables {
+            create_tables: vec![cwrite(table("t1"))],
+            read_tables: vec![],
+            update_tables: vec![],
+            delete_tables: vec![],
+            diagnostics: vec![],
+        })];
+        assert_crud_table_extraction(
+            "INSERT OR IGNORE INTO t1 (a) VALUES (1)",
+            expected,
+            vec![Box::new(SQLiteDialect {})],
+        );
+    }
+
+    #[test]
     fn test_insert_overwrite_buckets_target_as_create_and_delete() {
         use sql_insight::sqlparser::dialect::GenericDialect;
         // `INSERT OVERWRITE` replaces the target's existing data, so `t1` lands

--- a/sql-insight/tests/normalizer.rs
+++ b/sql-insight/tests/normalizer.rs
@@ -195,10 +195,11 @@ fn test_alphabetize_insert_columns_through_a_parenthesized_values() {
     // two rewrites half-applied.
     let sql = "INSERT INTO t1 (c, b, a) (VALUES (1, 2, 3))";
     let expected = vec!["INSERT INTO t1 (a, b, c) (VALUES (...))".into()];
+    // GenericDialect only: not every dialect parses the parenthesized form.
     assert_normalize(
         sql,
         expected,
-        all_dialects(),
+        vec![Box::new(sql_insight::sqlparser::dialect::GenericDialect {})],
         NormalizerOptions::new()
             .with_unify_values(true)
             .with_alphabetize_insert_columns(true),

--- a/sql-insight/tests/normalizer.rs
+++ b/sql-insight/tests/normalizer.rs
@@ -189,6 +189,23 @@ fn test_alphabetize_insert_columns() {
 }
 
 #[test]
+fn test_alphabetize_insert_columns_through_a_parenthesized_values() {
+    // `INSERT … (VALUES …)` nests the VALUES under a Query body; the
+    // alphabetize used to miss it while the unify still fired, leaving the
+    // two rewrites half-applied.
+    let sql = "INSERT INTO t1 (c, b, a) (VALUES (1, 2, 3))";
+    let expected = vec!["INSERT INTO t1 (a, b, c) (VALUES (...))".into()];
+    assert_normalize(
+        sql,
+        expected,
+        all_dialects(),
+        NormalizerOptions::new()
+            .with_unify_values(true)
+            .with_alphabetize_insert_columns(true),
+    );
+}
+
+#[test]
 fn test_do_not_alphabetize_insert_columns_when_values_not_unified() {
     let sql = "INSERT INTO t1 (c, b, a) SELECT x, y, z FROM t2";
     let expected = vec!["INSERT INTO t1 (c, b, a) SELECT x, y, z FROM t2".into()];

--- a/sql-insight/tests/table_operation_extractor.rs
+++ b/sql-insight/tests/table_operation_extractor.rs
@@ -658,6 +658,23 @@ mod ddl {
     }
 
     #[test]
+    fn alter_table_rename_to_surfaces_both_names() {
+        // `RENAME TO` writes both the old and the new table name — the
+        // table-level mirror of RENAME COLUMN surfacing both column names
+        // (the new name used to be invisible on every surface).
+        assert_ops(
+            "ALTER TABLE t1 RENAME TO t2",
+            TableOperation {
+                statement_kind: StatementKind::AlterTable,
+                reads: vec![],
+                writes: vec![twrite("t1"), twrite("t2")],
+                lineage: vec![],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn alter_view_emits_write_and_read_with_lineage() {
         // ALTER VIEW ... AS SELECT replaces the view definition with
         // a new SELECT body — semantically the same shape as CREATE


### PR DESCRIPTION
## Summary

Twelve small, independent correctness fixes — the remaining mechanical items of the behavior backlog, each reproduced against the live CLI (or a catalog probe) before fixing. Grouped by what was going wrong:

**Fabricated references**
- **An ordinal clause key trusted incomplete outputs.** `SELECT *, a FROM t ORDER BY 1` bound the ordinal to the written `a` — but the unexpanded `*` hides slots, so position 1 is unknown. The ordinal lookup now requires complete outputs (the positional-trust contract `Scope` documents) and otherwise binds the literal as written; a catalog that expands the wildcard re-enables it.
- **A Hive `LATERAL VIEW` never entered the scope.** `SELECT c FROM t LATERAL VIEW explode(arr) x AS c` read a phantom `t.c` with a false passthrough edge. Each view now joins onto the FROM as a lateral table function; the declared column aliases become its closed column list, so a generated column resolves to the view and traces to the function's arguments (a Transformation), at function granularity.
- **A select-level `EXCLUDE` (Redshift) was ignored**, so a cataloged wildcard expanded to every column and fabricated a read of the excluded ones. The projection now binds with expansion suppressed and flagged — the same all-or-nothing refusal the per-wildcard `EXCLUDE` already gets.
- **A column-less MERGE INSERT filled every catalog column**, fabricating `ColumnWrite`s for the surplus columns a narrower VALUES row never reaches. The fill now truncates to the row's arity, mirroring `bind_insert`.

- **An edge-case sweep of the LATERAL VIEW change found the wildcard interaction**: `SELECT * FROM t LATERAL VIEW explode(arr) x AS c` expands over the view's closed relation, but the slot trace's `TableFunction` arm predated slots ever being minted over one and returned nothing — the `c` slot came back edge-less. A slot qualified by the view's alias now traces to the function's arguments at function granularity (`arr → c`), like the named trace's arm.

**Dropped references**
- **A contested `EXCLUDED` reference vanished inside a conflict-action subquery.** The PostgreSQL-parity demotion (an unqualified reference in `ON CONFLICT DO UPDATE` is ambiguous between the existing row and `EXCLUDED`) was an expression post-pass that stopped at subquery boundaries. It is now a resolution rule — the action binds under a context carrying the `EXCLUDED` columns — so `SET a = (SELECT a + 1)` surfaces the ambiguous read; the post-pass is deleted.
- **A clause re-reference to an ambiguous output was dropped.** `SELECT a FROM t1, t2 GROUP BY a` counted one read: the identity test admitted only `Base` bindings. Any physical occurrence is identity now (`Base` / `Ambiguous` / `Unresolved` — the re-reference re-resolves to the same read, so no misattribution is possible).
- **ClickHouse `WITH FILL` bounds and `INTERPOLATE` fill expressions were never bound**; both now read as ORDER BY clause reads.
- **Hive's partition-placed insert column list (`INSERT INTO t PARTITION (…) (a, b)`) was dropped** as if no list were written, losing the writes and the positional pairing; `after_columns` now counts as the explicit list.

**Missing surfaces / half-applied rewrites**
- **SQLite `REPLACE INTO` / `INSERT OR REPLACE` never reached the CRUD Delete bucket** — both spellings parse to the SQLite conflict clause, not the `replace_into` flag the bucketing checked. (`OR IGNORE` stays create-only.)
- **`ALTER TABLE t RENAME TO t2`'s new name was invisible on every surface**; it now surfaces as a write beside the old, mirroring RENAME COLUMN surfacing both column names.
- **The normalizer's column alphabetization missed a parenthesized VALUES source** (`INSERT … (VALUES …)` nests it under a Query body), leaving the unify + alphabetize pair half-applied.
- **The table-granularity rustdoc claimed only `UnsupportedStatement` arises there**, though `TooManyTableQualifiers` is projected too (and pinned by tests).

## Tests

One or two whole-value pins per fix, in the module owning the construct — 915 tests total, clippy and rustdoc clean. No public API changes; output changes only where the previous output was silently wrong or missing, so this is a non-breaking fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

