### PR TITLE
fix: scope DISTINCT ON keys over the projection outputs

### DIFF
--- a/sql-insight/src/resolver/binder/expr.rs
+++ b/sql-insight/src/resolver/binder/expr.rs
@@ -943,19 +943,18 @@ impl<'a> Binder<'a> {
         exprs.iter().map(|e| self.bind_expr(e, scope)).collect()
     }
 
-    /// Filter-position reads from a SELECT's auxiliary clauses (`DISTINCT ON`
-    /// keys, `TOP n`, `PREWHERE`, `CONNECT BY` / `START WITH`, `CLUSTER BY` /
+    /// Filter-position reads from a SELECT's auxiliary clauses (`TOP n`,
+    /// `PREWHERE`, `CONNECT BY` / `START WITH`, `CLUSTER BY` /
     /// `DISTRIBUTE BY`, named `WINDOW` specs), resolved against the FROM
-    /// scope. None feed values. Hive `LATERAL VIEW` is *not* here — it is a
+    /// scope. None feed values. `DISTINCT ON` is *not* here — its keys see
+    /// the output aliases (PostgreSQL scopes them like ORDER BY), so they
+    /// bind post-projection in [`bind_select`](Self::bind_select). Hive `LATERAL VIEW` is *not* here — it is a
     /// value-feeding lateral table function, joined into the FROM by
     /// [`bind_select`](Self::bind_select). `QUALIFY` is *not* here — it
     /// filters on window / projection outputs (post-projection), so it binds
     /// against the output-aware scope in [`bind_select`](Self::bind_select).
     pub(super) fn select_clause_reads(&mut self, select: &Select, scope: &Scope) -> Vec<Expr> {
         let mut reads = Vec::new();
-        if let Some(Distinct::On(exprs)) = &select.distinct {
-            reads.extend(self.bind_exprs(exprs, scope));
-        }
         if let Some(top) = &select.top {
             if let Some(TopQuantity::Expr(expr)) = &top.quantity {
                 reads.push(self.bind_expr(expr, scope));

--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -711,6 +711,18 @@ impl<'a> Binder<'a> {
                 predicate: vec![self.bind_expr(qualify, &clause_scope)],
             });
         }
+        // `DISTINCT ON (keys)` picks one row per key group over the
+        // *projected* rows — PostgreSQL 18 (verified): an output alias is
+        // visible to the keys and *shadows* a same-named base column, like
+        // ORDER BY — so the keys bind against `clause_scope`: an identity
+        // output re-reads its column, an introduced alias binds `Derived`
+        // (the dependency is at the projection). Filter-position reads.
+        if let Some(Distinct::On(on)) = &select.distinct {
+            node = LogicalPlan::Filter(Filter {
+                input: Box::new(node),
+                predicate: self.bind_exprs(on, &clause_scope),
+            });
+        }
         // SORT BY (Hive) sees the outputs, like a trailing ORDER BY.
         let sort_keys = self.order_by_expr_keys(&select.sort_by, &clause_scope);
         if !sort_keys.is_empty() {

--- a/sql-insight/tests/column_operation_extractor/reads_semantics.rs
+++ b/sql-insight/tests/column_operation_extractor/reads_semantics.rs
@@ -1070,6 +1070,54 @@ mod output_alias_visibility {
     }
 
     #[test]
+    fn distinct_on_keys_see_the_output_aliases() {
+        // PostgreSQL 18 (verified): DISTINCT ON keys are scoped like ORDER
+        // BY — an output alias is visible, so `x` binds to the projection
+        // (`Derived`, no read; it used to surface a phantom `t.x`), while an
+        // identity key re-reads its column, occurrence-based.
+        assert_column_ops(
+            "SELECT DISTINCT ON (x) a AS x FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("x", 0))],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops(
+            "SELECT DISTINCT ON (a) a, b FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b"), read("t", "a")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    passthrough(col("t", "b"), out("b", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn distinct_on_alias_shadows_a_same_named_base_column() {
+        // PostgreSQL 18 (verified): with `a AS b` projected, DISTINCT ON (b)
+        // groups by the alias — the real column `b` is shadowed and not
+        // read.
+        assert_column_ops(
+            "SELECT DISTINCT ON (b) a AS b FROM t",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "a"), out("b", 0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn ambiguous_identity_output_still_counts_its_clause_occurrence() {
         // `a` is contested between t1 and t2, but the GROUP BY occurrence is
         // still a written physical reference — it re-resolves to the same


### PR DESCRIPTION
## Summary

`DISTINCT ON` keys bound against the FROM scope, so a key naming an output alias fell through to the base relation and fabricated a phantom read — `SELECT DISTINCT ON (x) a AS x FROM t` read a nonexistent `t.x`. Verified live on PostgreSQL 18: the keys are scoped like ORDER BY — an output alias is visible to them, and it *shadows* a same-named base column (`SELECT DISTINCT ON (b) a AS b FROM t` groups by the alias, not the column).

The keys now bind post-projection against the output-aware clause scope, through the existing clause-alias machinery: an introduced alias binds `Derived` (no read — the dependency is at the projection), an identity key re-reads its column occurrence-based, and a shadowed base column is not read. Structurally they sit as a filter above the projection, after QUALIFY in evaluation order.

## Tests

Three pins: the alias key (phantom read gone), the identity key (occurrence-consistent double read), and the shadowing case — each matching the live PostgreSQL behavior. Full workspace: 918 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)