### PR TITLE
fix: track quote and comment state when splitting interactive CLI statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,10 +817,22 @@ dependencies = [
  "memchr",
  "nix",
  "radix_trie",
+ "rustyline-derive",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
  "windows-sys",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e5587417a3c4e16a4415e8d7d07f80998ed835ade621d19dfbe9fbe3205b0f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/sql-insight-cli/Cargo.toml
+++ b/sql-insight-cli/Cargo.toml
@@ -47,7 +47,7 @@ sql-insight = { path = "../sql-insight", version = "0.4.0", features = ["serde"]
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 clap_mangen = "0.3"
-rustyline = "18.0.0"
+rustyline = { version = "18.0.0", features = ["derive"] }
 serde = "1.0.228"
 serde_json = "1.0.150"
 

--- a/sql-insight-cli/src/executor.rs
+++ b/sql-insight-cli/src/executor.rs
@@ -17,7 +17,7 @@ pub trait CliExecutable {
     fn execute(&self) -> Result<Vec<String>, Error>;
 }
 
-fn get_dialect(dialect_name: Option<&str>) -> Result<Box<dyn dialect::Dialect>, Error> {
+pub fn get_dialect(dialect_name: Option<&str>) -> Result<Box<dyn dialect::Dialect>, Error> {
     let dialect_name = dialect_name.unwrap_or("generic");
     dialect::dialect_from_str(dialect_name)
         .ok_or_else(|| Error::ArgumentError(format!("Dialect not found: {}", dialect_name)))

--- a/sql-insight-cli/src/main.rs
+++ b/sql-insight-cli/src/main.rs
@@ -307,7 +307,8 @@ impl Commands {
         // literal's indentation) kept verbatim.
         let mut editor: rustyline::Editor<SqlHelper, rustyline::history::DefaultHistory> =
             rustyline::Editor::new().map_err(|e| Error::IOError(e.to_string()))?;
-        editor.set_helper(Some(SqlHelper));
+        let dialect = crate::executor::get_dialect(self.common().dialect.as_deref())?;
+        editor.set_helper(Some(SqlHelper { dialect }));
         loop {
             let input = match editor.readline("sql> ") {
                 Ok(input) => input,
@@ -397,9 +398,13 @@ fn main() -> ExitCode {
 /// The rustyline helper: everything defaulted except the [`Validator`],
 /// which drives multiline editing — `Incomplete` until the input ends a
 /// statement (or is an `exit` / `quit` command, or blank), so Enter
-/// continues the same edit buffer instead of submitting.
+/// continues the same edit buffer instead of submitting. Holds the session
+/// dialect so completeness is judged by the same lexical rules the
+/// executor parses with.
 #[derive(rustyline::Completer, rustyline::Helper, rustyline::Highlighter, rustyline::Hinter)]
-struct SqlHelper;
+struct SqlHelper {
+    dialect: Box<dyn sql_insight::sqlparser::dialect::Dialect>,
+}
 
 impl rustyline::validate::Validator for SqlHelper {
     fn validate(
@@ -410,7 +415,7 @@ impl rustyline::validate::Validator for SqlHelper {
         let complete = trimmed.is_empty()
             || trimmed.eq_ignore_ascii_case("exit")
             || trimmed.eq_ignore_ascii_case("quit")
-            || statement_complete(ctx.input());
+            || statement_complete(self.dialect.as_ref(), ctx.input());
         Ok(if complete {
             rustyline::validate::ValidationResult::Valid(None)
         } else {
@@ -419,112 +424,100 @@ impl rustyline::validate::Validator for SqlHelper {
     }
 }
 
-/// Whether the buffered input ends a statement: its last significant
-/// character *outside* any string literal, quoted identifier, or comment is
-/// `;`. The scan tracks the SQL-standard quote forms — `'…'` strings and
-/// `"…"` / `` `…` `` quoted identifiers, each escaping its own quote by
-/// doubling (a doubled quote toggles the state out and straight back in, so
-/// plain toggling handles it) — plus `--` line comments and nesting
-/// `/* … */` block comments (PostgreSQL nests them). Not modelled:
-/// dollar-quoted strings (`$tag$…$tag$`) and dialect-specific backslash
-/// escapes — a `;` inside those may still split early, best-effort.
-fn statement_complete(input: &str) -> bool {
-    #[derive(PartialEq)]
-    enum State {
-        Top,
-        Single,
-        Double,
-        Backtick,
-        LineComment,
-        BlockComment(u32),
-    }
-    let mut state = State::Top;
-    let mut last_significant = None;
-    let mut chars = input.chars().peekable();
-    while let Some(c) = chars.next() {
-        match state {
-            State::Top => match c {
-                '\'' => state = State::Single,
-                '"' => state = State::Double,
-                '`' => state = State::Backtick,
-                '-' if chars.peek() == Some(&'-') => {
-                    chars.next();
-                    state = State::LineComment;
-                }
-                '/' if chars.peek() == Some(&'*') => {
-                    chars.next();
-                    state = State::BlockComment(1);
-                }
-                _ => {
-                    if !c.is_whitespace() {
-                        last_significant = Some(c);
-                    }
-                }
-            },
-            State::Single if c == '\'' => state = State::Top,
-            State::Double if c == '"' => state = State::Top,
-            State::Backtick if c == '`' => state = State::Top,
-            State::LineComment if c == '\n' => state = State::Top,
-            State::BlockComment(depth) => {
-                if c == '*' && chars.peek() == Some(&'/') {
-                    chars.next();
-                    state = if depth == 1 {
-                        State::Top
-                    } else {
-                        State::BlockComment(depth - 1)
-                    };
-                } else if c == '/' && chars.peek() == Some(&'*') {
-                    chars.next();
-                    state = State::BlockComment(depth + 1);
-                }
-            }
-            State::Single | State::Double | State::Backtick | State::LineComment => {}
+/// Whether the buffered input ends a statement: its last token outside
+/// whitespace and comments is `;`, judged by **sqlparser's own tokenizer**
+/// under the session dialect — the same lexical rules the executor will
+/// parse with, so string / identifier quoting (dialect escapes included),
+/// dollar quoting, brackets, and every comment form can't diverge from the
+/// real parse. An "unterminated / EOF" tokenizer error means the input is
+/// still inside a literal or comment — incomplete, keep editing; any other
+/// tokenizer error won't be fixed by more input, so the statement counts as
+/// complete and the executor surfaces the real error visibly instead of
+/// trapping the prompt.
+fn statement_complete(dialect: &dyn sql_insight::sqlparser::dialect::Dialect, input: &str) -> bool {
+    use sql_insight::sqlparser::tokenizer::{Token, Tokenizer};
+    match Tokenizer::new(dialect, input).tokenize() {
+        Err(e) => {
+            let message = e.to_string();
+            !(message.contains("Unterminated") || message.contains("EOF"))
         }
+        Ok(tokens) => matches!(
+            tokens
+                .iter()
+                .rev()
+                .find(|t| !matches!(t, Token::Whitespace(_))),
+            Some(Token::SemiColon)
+        ),
     }
-    // End of input closes a line comment (a newline would); an open string
-    // or block comment keeps the statement incomplete.
-    matches!(state, State::Top | State::LineComment) && last_significant == Some(';')
 }
 
 #[cfg(test)]
 mod tests {
     use super::statement_complete;
+    use sql_insight::sqlparser::dialect::{
+        Dialect, GenericDialect, MsSqlDialect, MySqlDialect, PostgreSqlDialect,
+    };
+
+    fn complete(dialect: &dyn Dialect, input: &str) -> bool {
+        statement_complete(dialect, input)
+    }
 
     #[test]
     fn splits_on_a_top_level_semicolon_only() {
-        assert!(statement_complete("SELECT 1;"));
-        assert!(statement_complete("SELECT 1 ;  "));
-        assert!(!statement_complete("SELECT 1"));
-        // A trailing comment after the terminator doesn't hide it.
-        assert!(statement_complete("SELECT 1; -- done"));
-        assert!(statement_complete("SELECT 1; /* done */"));
+        let g = GenericDialect {};
+        assert!(complete(&g, "SELECT 1;"));
+        assert!(complete(&g, "SELECT 1 ;  "));
+        assert!(!complete(&g, "SELECT 1"));
+        // A trailing comment after the terminator doesn't hide it (comments
+        // are whitespace tokens).
+        assert!(complete(&g, "SELECT 1; -- done"));
+        assert!(complete(&g, "SELECT 1; /* done */"));
     }
 
     #[test]
     fn a_semicolon_inside_a_literal_does_not_terminate() {
+        let g = GenericDialect {};
         // The literal continues on the next line — the old line-suffix check
         // executed the unterminated statement here.
-        assert!(!statement_complete("SELECT 'a;\n"));
-        assert!(statement_complete("SELECT 'a;\nb';"));
-        // Quoted identifiers likewise.
-        assert!(!statement_complete("SELECT \"a;\n"));
-        assert!(!statement_complete("SELECT `a;\n"));
-    }
-
-    #[test]
-    fn doubled_quotes_stay_inside_the_literal() {
+        assert!(!complete(&g, "SELECT 'a;\n"));
+        assert!(complete(&g, "SELECT 'a;\nb';"));
+        // Quoted identifiers likewise ("…" and MySQL `…`).
+        assert!(!complete(&g, "SELECT \"a;\n"));
+        assert!(!complete(&MySqlDialect {}, "SELECT `a;\n"));
         // `''` is an escaped quote: `'a'';'` is one literal containing `a';`.
-        assert!(!statement_complete("SELECT 'a'';'"));
-        assert!(statement_complete("SELECT 'a'';';"));
+        assert!(!complete(&g, "SELECT 'a'';'"));
+        assert!(complete(&g, "SELECT 'a'';';"));
     }
 
     #[test]
     fn comments_hide_their_semicolons() {
-        assert!(!statement_complete("SELECT 1 -- ;\n"));
-        assert!(statement_complete("SELECT 1 -- ;\n;"));
-        assert!(!statement_complete("SELECT 1 /* ; */"));
-        // PostgreSQL nests block comments.
-        assert!(!statement_complete("SELECT 1 /* /* ; */ ; */"));
-        assert!(statement_complete("SELECT 1 /* /* ; */ */;"));
+        let g = GenericDialect {};
+        assert!(!complete(&g, "SELECT 1 -- ;\n"));
+        assert!(complete(&g, "SELECT 1 -- ;\n;"));
+        assert!(!complete(&g, "SELECT 1 /* ; */"));
+        // An unterminated block comment keeps the statement open.
+        assert!(!complete(&g, "SELECT 1; /* ;"));
+    }
+
+    #[test]
+    fn dialect_lexing_is_the_executors() {
+        // PostgreSQL dollar quoting — the everyday CREATE FUNCTION shape —
+        // and a `$1` placeholder, which is not an opener.
+        let pg = PostgreSqlDialect {};
+        assert!(!complete(&pg, "SELECT $$a;$$"));
+        assert!(complete(&pg, "SELECT $$a;$$;"));
+        assert!(complete(&pg, "SELECT $body$ x; y; $body$;"));
+        assert!(complete(&pg, "SELECT $1;"));
+        // MySQL: `\'` escapes inside the literal, and `#` starts a comment —
+        // both judged by the dialect's own lexer (the hand-rolled scanner
+        // this replaced had to punt on both).
+        let my = MySqlDialect {};
+        assert!(!complete(&my, "SELECT 'a\\';"));
+        assert!(complete(&my, "SELECT 'a\\'';"));
+        assert!(complete(&my, "SELECT 1; # done"));
+        // MSSQL bracket identifiers hide their `;`.
+        let ms = MsSqlDialect {};
+        assert!(!complete(&ms, "SELECT [a;b"));
+        assert!(complete(&ms, "SELECT [a;b] FROM t;"));
     }
 }

--- a/sql-insight-cli/src/main.rs
+++ b/sql-insight-cli/src/main.rs
@@ -321,16 +321,23 @@ impl Commands {
                 Err(e) => return Err(Error::IOError(e.to_string())),
             };
             let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
+            if input_buffer.is_empty() {
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if trimmed.eq_ignore_ascii_case("exit") || trimmed.eq_ignore_ascii_case("quit") {
+                    break;
+                }
             }
-            let _ = editor.add_history_entry(trimmed);
-            if trimmed.eq_ignore_ascii_case("exit") || trimmed.eq_ignore_ascii_case("quit") {
-                break;
+            if !trimmed.is_empty() {
+                let _ = editor.add_history_entry(trimmed);
             }
-            input_buffer.push_str(trimmed);
+            // Keep the line verbatim: a statement may continue a string
+            // literal from the previous line, whose leading / trailing
+            // whitespace is content (trimming destroyed it).
+            input_buffer.push_str(&line);
             input_buffer.push('\n');
-            if trimmed.ends_with(';') {
+            if statement_complete(&input_buffer) {
                 match self.executor(std::mem::take(&mut input_buffer)).execute() {
                     Ok(result) => result.iter().for_each(|r| println!("{r}")),
                     Err(e) => eprintln!("Error: {e}"),
@@ -399,5 +406,115 @@ fn main() -> ExitCode {
             eprintln!("Error: {}", e);
             ExitCode::FAILURE
         }
+    }
+}
+
+/// Whether the buffered input ends a statement: its last significant
+/// character *outside* any string literal, quoted identifier, or comment is
+/// `;`. The scan tracks the SQL-standard quote forms — `'…'` strings and
+/// `"…"` / `` `…` `` quoted identifiers, each escaping its own quote by
+/// doubling (a doubled quote toggles the state out and straight back in, so
+/// plain toggling handles it) — plus `--` line comments and nesting
+/// `/* … */` block comments (PostgreSQL nests them). Not modelled:
+/// dollar-quoted strings (`$tag$…$tag$`) and dialect-specific backslash
+/// escapes — a `;` inside those may still split early, best-effort.
+fn statement_complete(input: &str) -> bool {
+    #[derive(PartialEq)]
+    enum State {
+        Top,
+        Single,
+        Double,
+        Backtick,
+        LineComment,
+        BlockComment(u32),
+    }
+    let mut state = State::Top;
+    let mut last_significant = None;
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        match state {
+            State::Top => match c {
+                '\'' => state = State::Single,
+                '"' => state = State::Double,
+                '`' => state = State::Backtick,
+                '-' if chars.peek() == Some(&'-') => {
+                    chars.next();
+                    state = State::LineComment;
+                }
+                '/' if chars.peek() == Some(&'*') => {
+                    chars.next();
+                    state = State::BlockComment(1);
+                }
+                _ => {
+                    if !c.is_whitespace() {
+                        last_significant = Some(c);
+                    }
+                }
+            },
+            State::Single if c == '\'' => state = State::Top,
+            State::Double if c == '"' => state = State::Top,
+            State::Backtick if c == '`' => state = State::Top,
+            State::LineComment if c == '\n' => state = State::Top,
+            State::BlockComment(depth) => {
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    state = if depth == 1 {
+                        State::Top
+                    } else {
+                        State::BlockComment(depth - 1)
+                    };
+                } else if c == '/' && chars.peek() == Some(&'*') {
+                    chars.next();
+                    state = State::BlockComment(depth + 1);
+                }
+            }
+            State::Single | State::Double | State::Backtick | State::LineComment => {}
+        }
+    }
+    // End of input closes a line comment (a newline would); an open string
+    // or block comment keeps the statement incomplete.
+    matches!(state, State::Top | State::LineComment) && last_significant == Some(';')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::statement_complete;
+
+    #[test]
+    fn splits_on_a_top_level_semicolon_only() {
+        assert!(statement_complete("SELECT 1;"));
+        assert!(statement_complete("SELECT 1 ;  "));
+        assert!(!statement_complete("SELECT 1"));
+        // A trailing comment after the terminator doesn't hide it.
+        assert!(statement_complete("SELECT 1; -- done"));
+        assert!(statement_complete("SELECT 1; /* done */"));
+    }
+
+    #[test]
+    fn a_semicolon_inside_a_literal_does_not_terminate() {
+        // The literal continues on the next line — the old line-suffix check
+        // executed the unterminated statement here.
+        assert!(!statement_complete("SELECT 'a;\n"));
+        assert!(statement_complete("SELECT 'a;\nb';"));
+        // Quoted identifiers likewise.
+        assert!(!statement_complete("SELECT \"a;\n"));
+        assert!(!statement_complete("SELECT `a;\n"));
+    }
+
+    #[test]
+    fn doubled_quotes_stay_inside_the_literal() {
+        // `''` is an escaped quote: `'a'';'` is one literal containing `a';`.
+        assert!(!statement_complete("SELECT 'a'';'"));
+        assert!(statement_complete("SELECT 'a'';';"));
+    }
+
+    #[test]
+    fn comments_hide_their_semicolons() {
+        assert!(!statement_complete("SELECT 1 -- ;\n"));
+        assert!(statement_complete("SELECT 1 -- ;\n;"));
+        assert!(!statement_complete("SELECT 1 /* ; */"));
+        // PostgreSQL nests block comments.
+        assert!(!statement_complete("SELECT 1 /* /* ; */ ; */"));
+        assert!(statement_complete("SELECT 1 /* /* ; */ */;"));
     }
 }

--- a/sql-insight-cli/src/main.rs
+++ b/sql-insight-cli/src/main.rs
@@ -300,48 +300,33 @@ impl Commands {
             "Entering interactive mode. Type sql statement end with `;` to execute. \
              Type `exit` or `quit` to exit."
         );
-        let mut editor =
-            rustyline::DefaultEditor::new().map_err(|e| Error::IOError(e.to_string()))?;
-
-        let mut input_buffer = String::new();
+        // Statement continuation is rustyline's multiline mechanism: the
+        // helper's `Validator` answers `Incomplete` until the buffer ends a
+        // statement, so Enter inserts a newline and editing continues across
+        // lines — one history entry per whole statement, content (a string
+        // literal's indentation) kept verbatim.
+        let mut editor: rustyline::Editor<SqlHelper, rustyline::history::DefaultHistory> =
+            rustyline::Editor::new().map_err(|e| Error::IOError(e.to_string()))?;
+        editor.set_helper(Some(SqlHelper));
         loop {
-            let prompt = if input_buffer.is_empty() {
-                "sql> "
-            } else {
-                "  -> "
-            };
-            let line = match editor.readline(prompt) {
-                Ok(line) => line,
-                // Ctrl-C clears the in-progress statement; Ctrl-D / EOF exits.
-                Err(rustyline::error::ReadlineError::Interrupted) => {
-                    input_buffer.clear();
-                    continue;
-                }
+            let input = match editor.readline("sql> ") {
+                Ok(input) => input,
+                // Ctrl-C discards the in-progress statement; Ctrl-D / EOF exits.
+                Err(rustyline::error::ReadlineError::Interrupted) => continue,
                 Err(rustyline::error::ReadlineError::Eof) => break,
                 Err(e) => return Err(Error::IOError(e.to_string())),
             };
-            let trimmed = line.trim();
-            if input_buffer.is_empty() {
-                if trimmed.is_empty() {
-                    continue;
-                }
-                if trimmed.eq_ignore_ascii_case("exit") || trimmed.eq_ignore_ascii_case("quit") {
-                    break;
-                }
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                continue;
             }
-            if !trimmed.is_empty() {
-                let _ = editor.add_history_entry(trimmed);
+            let _ = editor.add_history_entry(&input);
+            if trimmed.eq_ignore_ascii_case("exit") || trimmed.eq_ignore_ascii_case("quit") {
+                break;
             }
-            // Keep the line verbatim: a statement may continue a string
-            // literal from the previous line, whose leading / trailing
-            // whitespace is content (trimming destroyed it).
-            input_buffer.push_str(&line);
-            input_buffer.push('\n');
-            if statement_complete(&input_buffer) {
-                match self.executor(std::mem::take(&mut input_buffer)).execute() {
-                    Ok(result) => result.iter().for_each(|r| println!("{r}")),
-                    Err(e) => eprintln!("Error: {e}"),
-                }
+            match self.executor(input).execute() {
+                Ok(result) => result.iter().for_each(|r| println!("{r}")),
+                Err(e) => eprintln!("Error: {e}"),
             }
         }
 
@@ -406,6 +391,31 @@ fn main() -> ExitCode {
             eprintln!("Error: {}", e);
             ExitCode::FAILURE
         }
+    }
+}
+
+/// The rustyline helper: everything defaulted except the [`Validator`],
+/// which drives multiline editing — `Incomplete` until the input ends a
+/// statement (or is an `exit` / `quit` command, or blank), so Enter
+/// continues the same edit buffer instead of submitting.
+#[derive(rustyline::Completer, rustyline::Helper, rustyline::Highlighter, rustyline::Hinter)]
+struct SqlHelper;
+
+impl rustyline::validate::Validator for SqlHelper {
+    fn validate(
+        &self,
+        ctx: &mut rustyline::validate::ValidationContext,
+    ) -> rustyline::Result<rustyline::validate::ValidationResult> {
+        let trimmed = ctx.input().trim();
+        let complete = trimmed.is_empty()
+            || trimmed.eq_ignore_ascii_case("exit")
+            || trimmed.eq_ignore_ascii_case("quit")
+            || statement_complete(ctx.input());
+        Ok(if complete {
+            rustyline::validate::ValidationResult::Valid(None)
+        } else {
+            rustyline::validate::ValidationResult::Incomplete
+        })
     }
 }
 

--- a/sql-insight-cli/src/main.rs
+++ b/sql-insight-cli/src/main.rs
@@ -297,7 +297,8 @@ impl Commands {
 
     fn entering_interactive_mode(&self) -> Result<(), Error> {
         println!(
-            "Entering interactive mode. Type sql statement end with `;` to execute. \
+            "Entering interactive mode. End each statement with `;` to execute — \
+             Enter continues a statement across lines until then. \
              Type `exit` or `quit` to exit."
         );
         // Statement continuation is rustyline's multiline mechanism: the
@@ -429,17 +430,25 @@ impl rustyline::validate::Validator for SqlHelper {
 /// under the session dialect — the same lexical rules the executor will
 /// parse with, so string / identifier quoting (dialect escapes included),
 /// dollar quoting, brackets, and every comment form can't diverge from the
-/// real parse. An "unterminated / EOF" tokenizer error means the input is
-/// still inside a literal or comment — incomplete, keep editing; any other
-/// tokenizer error won't be fixed by more input, so the statement counts as
-/// complete and the executor surfaces the real error visibly instead of
-/// trapping the prompt.
+/// real parse. A *recoverable* tokenizer error — the input is still inside
+/// a literal or comment, so more input can fix it — means incomplete, keep
+/// editing; any other tokenizer error won't be fixed by more input, so the
+/// statement counts as complete and the executor surfaces the real error
+/// visibly instead of trapping the prompt. `TokenizerError` carries no
+/// error kind, so recoverability is read off the message: the three
+/// signatures below cover every unterminated-construct site in sqlparser
+/// 0.62, and deliberately exclude mixed messages like `"Invalid space,
+/// tab, newline, or EOF after 'q''"` (an Oracle `q'` followed by a
+/// newline is *not* fixable by more input — matching its "EOF" would trap
+/// the prompt).
 fn statement_complete(dialect: &dyn sql_insight::sqlparser::dialect::Dialect, input: &str) -> bool {
     use sql_insight::sqlparser::tokenizer::{Token, Tokenizer};
     match Tokenizer::new(dialect, input).tokenize() {
         Err(e) => {
-            let message = e.to_string();
-            !(message.contains("Unterminated") || message.contains("EOF"))
+            let recoverable = e.message.contains("Unterminated")
+                || e.message.contains("before EOF")
+                || e.message.contains("Unexpected EOF");
+            !recoverable
         }
         Ok(tokens) => matches!(
             tokens
@@ -519,5 +528,16 @@ mod tests {
         let ms = MsSqlDialect {};
         assert!(!complete(&ms, "SELECT [a;b"));
         assert!(complete(&ms, "SELECT [a;b] FROM t;"));
+    }
+
+    #[test]
+    fn an_unrecoverable_tokenizer_error_submits_instead_of_trapping() {
+        // An Oracle `q'` followed by a newline is a lexical error no amount
+        // of further input can fix — its message mentions "EOF" as one of
+        // several causes, but it must count as complete so the executor
+        // surfaces the real error instead of the prompt swallowing Enter
+        // forever.
+        use sql_insight::sqlparser::dialect::GenericDialect;
+        assert!(complete(&GenericDialect {}, "SELECT q'\n"));
     }
 }


### PR DESCRIPTION
## Summary

The interactive mode's statement splitting was purely line-based: execute once a line ends in `;`, and trim every line before buffering. Both halves corrupted multi-line string literals — `SELECT 'a;` on one line executed immediately as an unterminated statement instead of waiting for the literal to close, and the leading / trailing whitespace of a continued literal line (its *content*) was trimmed away.

Continuation now rides rustyline's own multiline mechanism: a `Validator` answers `Incomplete` until the buffer ends a statement, so Enter inserts a newline in the *same* edit buffer — lines are editable across the statement, a whole statement lands as one history entry, content (a literal's indentation) is kept verbatim, and the hand-rolled buffer / continuation-prompt loop is gone. Completeness itself is judged by **sqlparser's own tokenizer** under the session dialect (`--dialect`): a statement is complete when the last non-whitespace token is a semicolon (comments are whitespace tokens, so a trailing comment doesn't hide the terminator). Because the judge and the executor share one lexer, dialect-specific forms are correct by construction: MySQL backslash escapes and `#` comments, PostgreSQL dollar quoting (`$$…$$` / `$tag$…$tag$`, with `$1` placeholders not mistaken for openers), MSSQL bracket identifiers, and nested block comments. A *recoverable* tokenizer error — one of the three unterminated-construct signatures (`Unterminated`, `before EOF`, `Unexpected EOF`), which cover every such site in sqlparser 0.62 — means the input is still inside a literal or comment: incomplete, keep editing. Any other tokenizer error won't be fixed by more input, so the statement submits and the executor surfaces the real error instead of trapping the prompt; notably the mixed quote-delimited-literal message (an Oracle `q'` followed by a newline) mentions EOF without being recoverable, and a bare EOF-substring match would have swallowed Enter forever there. `TokenizerError` exposes no structured kind, so the signature match is pinned by tests. `exit` / `quit` (and blank input) validate as complete commands at the prompt; inside an in-progress statement they are ordinary content.

## Tests

Unit tests on the completeness judge: top-level splitting (trailing comments included), literal-internal `;` across the quote forms with doubled-quote escapes, comment termination, and the dialect-specific lexing (PostgreSQL dollar quotes and placeholders, MySQL backslash escapes and `#` comments, MSSQL brackets), plus the unrecoverable-error case that must submit rather than trap the prompt. Full workspace: 923 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


