### PR TITLE
feat: expose a data-modifying CTE's RETURNING as its output columns

### DIFF
--- a/sql-insight/src/resolver/binder/query.rs
+++ b/sql-insight/src/resolver/binder/query.rs
@@ -514,12 +514,20 @@ impl<'a> Binder<'a> {
                 None => (LogicalPlan::Empty, Scope::default()),
             },
             // `WITH … INSERT/UPDATE/DELETE/MERGE …`: the DML statement is the
-            // query body (the parser wraps a CTE-prefixed DML this way). Bind it
-            // to its DML root; it exposes no output scope to an enclosing query.
+            // query body (the parser wraps a CTE-prefixed DML this way). Bind
+            // it to its DML root. Its RETURNING projection is the output the
+            // body exposes — a data-modifying CTE's consumer reads exactly
+            // those columns (`WITH c AS (INSERT … RETURNING a) SELECT a FROM
+            // c`) — so the scope carries them like a SELECT's outputs; with
+            // no RETURNING the body exposes nothing.
             SetExpr::Insert(statement)
             | SetExpr::Update(statement)
             | SetExpr::Delete(statement)
-            | SetExpr::Merge(statement) => (self.bind_statement(statement), Scope::default()),
+            | SetExpr::Merge(statement) => {
+                let plan = self.bind_statement(statement);
+                let scope = self.dml_returning_scope(statement, &plan);
+                (plan, scope)
+            }
             // A set operation: result columns are the left operand's (names
             // from the left, positional merge). The result is positionally
             // determinate only when *every* branch is — a right branch with an
@@ -907,6 +915,44 @@ impl<'a> Binder<'a> {
             }
         }
         common
+    }
+
+    /// The output scope a DML query body (a data-modifying CTE) exposes:
+    /// its RETURNING projection's columns, empty without one. Completeness
+    /// is conservative — a RETURNING *wildcard written in the SQL* marks the
+    /// outputs incomplete even when it expanded (the expansion flag isn't
+    /// carried on the plan), so a positional consumer (an outer `SELECT *`
+    /// over the CTE) suppresses rather than trusts a possibly-partial list.
+    fn dml_returning_scope(&self, statement: &Statement, plan: &LogicalPlan) -> Scope {
+        let returning = match plan {
+            LogicalPlan::Insert(i) => &i.returning,
+            LogicalPlan::Update(u) => &u.returning,
+            LogicalPlan::Delete(d) => &d.returning,
+            LogicalPlan::Merge(m) => &m.returning,
+            _ => return Scope::default(),
+        };
+        if returning.is_empty() {
+            return Scope::default();
+        }
+        let ast_items = match statement {
+            Statement::Insert(i) => i.returning.as_deref(),
+            Statement::Update(u) => u.returning.as_deref(),
+            Statement::Delete(d) => d.returning.as_deref(),
+            Statement::Merge(m) => m.output.as_ref().map(|o| match o {
+                sqlparser::ast::OutputClause::Output { select_items, .. }
+                | sqlparser::ast::OutputClause::Returning { select_items, .. } => {
+                    select_items.as_slice()
+                }
+            }),
+            _ => None,
+        };
+        let has_wildcard = ast_items.into_iter().flatten().any(|item| {
+            matches!(
+                item,
+                SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(..)
+            )
+        });
+        Scope::default().with_query_outputs(self.output_cols(returning), !has_wildcard)
     }
 
     /// Bind a bare named table into a read `Scan` plus a single-relation scope

--- a/sql-insight/src/resolver/origins.rs
+++ b/sql-insight/src/resolver/origins.rs
@@ -520,15 +520,36 @@ fn origins_into<'a>(
         // traversal. So a `Scan` reached here (e.g. the other side of a join
         // the qualified name doesn't own) contributes nothing.
         LogicalPlan::Scan(_) | LogicalPlan::Values(_) | LogicalPlan::Empty => Vec::new(),
-        // DML/DDL roots are not column producers traced into here.
-        LogicalPlan::Insert(_)
-        | LogicalPlan::Update(_)
-        | LogicalPlan::Delete(_)
-        | LogicalPlan::Merge(_)
-        | LogicalPlan::CreateTableAs(_)
+        // A DML root's RETURNING projection is the output a data-modifying
+        // CTE body exposes — a named reference through the CTE traces into
+        // it like a SELECT's projection (the returning expressions resolve
+        // against the write target / source, so their refs are mostly
+        // `Base`, traced over the DML's read input).
+        LogicalPlan::Insert(i) => returning_origins(&i.returning, &i.input, name, context),
+        LogicalPlan::Update(u) => returning_origins(&u.returning, &u.input, name, context),
+        LogicalPlan::Delete(d) => returning_origins(&d.returning, &d.input, name, context),
+        LogicalPlan::Merge(m) => returning_origins(&m.returning, &m.source, name, context),
+        LogicalPlan::CreateTableAs(_)
         | LogicalPlan::CreateView(_)
         | LogicalPlan::AlterTable(_)
         | LogicalPlan::Drop(_) => Vec::new(),
+    }
+}
+
+/// The named output of a DML root's RETURNING projection, traced to its
+/// origins over the DML's read input — the output a data-modifying CTE
+/// body exposes (empty without a RETURNING).
+fn returning_origins<'a>(
+    returning: &'a [NamedExpr],
+    input: &'a LogicalPlan,
+    name: &Ident,
+    context: &mut TraceContext<'a>,
+) -> Vec<(ColumnRead, ColumnLineageKind)> {
+    match named_position(returning, name, context.casing.column)
+        .and_then(|i| resolved_output_expr(returning, i))
+    {
+        Some(expr) => origins_of_expr(expr, input, context),
+        None => Vec::new(),
     }
 }
 
@@ -741,6 +762,29 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
         // stays edge-less, best-effort. (A join *below* a projection never
         // reaches here — the projection claims the walk first.)
         LogicalPlan::Join(jn) => collect_operands(&jn.left, ctes, out),
+        // A DML root's RETURNING projection is its positional output (a
+        // data-modifying CTE's exposed columns — empty outputs claim
+        // nothing).
+        LogicalPlan::Insert(i) => out.push(Operand {
+            outputs: &i.returning,
+            input: &i.input,
+            ctes: ctes.to_vec(),
+        }),
+        LogicalPlan::Update(u) => out.push(Operand {
+            outputs: &u.returning,
+            input: &u.input,
+            ctes: ctes.to_vec(),
+        }),
+        LogicalPlan::Delete(d) => out.push(Operand {
+            outputs: &d.returning,
+            input: &d.input,
+            ctes: ctes.to_vec(),
+        }),
+        LogicalPlan::Merge(m) => out.push(Operand {
+            outputs: &m.returning,
+            input: &m.source,
+            ctes: ctes.to_vec(),
+        }),
         // No projection at this level — a relation that doesn't carry a
         // SELECT list (a `Scan`, a join below a projection, a DML / DDL root,
         // …) yields no operands. Listed explicitly so a new operator that
@@ -751,10 +795,6 @@ fn collect_operands<'a>(op: &'a LogicalPlan, ctes: &[&'a Cte], out: &mut Vec<Ope
         | LogicalPlan::CteRef(_)
         | LogicalPlan::Values(_)
         | LogicalPlan::Empty
-        | LogicalPlan::Insert(_)
-        | LogicalPlan::Update(_)
-        | LogicalPlan::Delete(_)
-        | LogicalPlan::Merge(_)
         | LogicalPlan::CreateTableAs(_)
         | LogicalPlan::CreateView(_)
         | LogicalPlan::AlterTable(_)

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -155,6 +155,61 @@ mod with_in_dml {
     }
 
     #[test]
+    fn every_dml_kind_exposes_returning_on_both_trace_paths() {
+        // The named path (a reference by name) and the positional path (a
+        // star consumer) each have a per-DML-kind arm — INSERT and UPDATE
+        // are pinned above, DELETE and MERGE (`OUTPUT` family) here, with a
+        // star over DELETE / UPDATE covering the positional operands.
+        assert_column_ops(
+            "WITH c AS (DELETE FROM t WHERE f = 1 RETURNING id, x) \
+             SELECT * FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "f"), read("t", "id"), read("t", "x")],
+                writes: vec![],
+                lineage: vec![
+                    passthrough(col("t", "id"), out("id", 0)),
+                    passthrough(col("t", "x"), out("x", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops(
+            "WITH c AS (MERGE INTO t USING s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET t.a = s.a RETURNING s.b) \
+             SELECT b FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read("t", "id"),
+                    read("s", "id"),
+                    read("s", "a"),
+                    read("s", "b"),
+                ],
+                writes: vec![write("t", "a")],
+                lineage: vec![
+                    passthrough(col("s", "a"), relation("t", "a")),
+                    passthrough(col("s", "b"), out("b", 0)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops(
+            "WITH c AS (UPDATE t SET a = 1 RETURNING a, b) SELECT * FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "b")],
+                writes: vec![write("t", "a")],
+                lineage: vec![
+                    passthrough(col("t", "a"), out("a", 0)),
+                    passthrough(col("t", "b"), out("b", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn dml_cte_referenced_twice_traces_per_reference() {
         // PostgreSQL runs a data-modifying CTE once however often it is
         // referenced; each reference still traces its own output position

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -207,6 +207,40 @@ mod with_in_dml {
                 diagnostics: vec![],
             },
         );
+        // The DELETE named path, and the `OUTPUT` spelling of the MERGE
+        // clause under a star consumer (positional path).
+        assert_column_ops(
+            "WITH c AS (DELETE FROM t WHERE f = 1 RETURNING id) SELECT id FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "f"), read("t", "id")],
+                writes: vec![],
+                lineage: vec![passthrough(col("t", "id"), out("id", 0))],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops(
+            "WITH c AS (MERGE INTO t USING s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET t.a = s.a OUTPUT s.b, s.k) \
+             SELECT * FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![
+                    read("t", "id"),
+                    read("s", "id"),
+                    read("s", "a"),
+                    read("s", "b"),
+                    read("s", "k"),
+                ],
+                writes: vec![write("t", "a")],
+                lineage: vec![
+                    passthrough(col("s", "a"), relation("t", "a")),
+                    passthrough(col("s", "b"), out("b", 0)),
+                    passthrough(col("s", "k"), out("k", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
     }
 
     #[test]

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -71,17 +71,85 @@ mod with_in_dml {
         // *statement's* WITH, so it must stay outermost — wrapping the create
         // around it buried the CTE's INSERT inside the root's input, where
         // the write-root collection never descends, and `t1`'s write vanished
-        // from every surface. (The unresolved outer `a` is a separate known
-        // gap: a DML CTE's RETURNING columns aren't exposed to references.)
+        // from every surface. The outer `a` resolves through the CTE's
+        // RETURNING (its exposed output), so the flow reaches `t2` end to
+        // end: `t1.a → t2.a`.
         assert_column_ops(
             "WITH c AS (INSERT INTO t1 (a) VALUES (1) RETURNING a) \
              SELECT a INTO t2 FROM c",
             ColumnOperation {
                 statement_kind: StatementKind::CreateTable,
-                reads: vec![read("t1", "a"), unresolved("a")],
+                reads: vec![read("t1", "a")],
                 writes: vec![write("t1", "a"), write("t2", "a")],
-                lineage: vec![passthrough(unresolved("a"), relation("t2", "a"))],
+                lineage: vec![passthrough(col("t1", "a"), relation("t2", "a"))],
                 diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn dml_cte_returning_is_the_ctes_exposed_output() {
+        // A data-modifying CTE exposes its RETURNING projection: the outer
+        // reference resolves through it (it used to dangle `Unresolved`)
+        // and traces to the returning expression's sources — a rename
+        // (`a AS x`) and an UPDATE body included.
+        assert_column_ops(
+            "WITH c AS (INSERT INTO t1 (a) VALUES (1) RETURNING a) \
+             SELECT a FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t1", "a")],
+                writes: vec![write("t1", "a")],
+                lineage: vec![passthrough(col("t1", "a"), out("a", 0))],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops(
+            "WITH c AS (UPDATE t SET a = a + 1 RETURNING a AS x) \
+             SELECT x FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t", "a"), read("t", "a")],
+                writes: vec![write("t", "a")],
+                lineage: vec![
+                    transformation(col("t", "a"), relation("t", "a")),
+                    passthrough(col("t", "a"), out("x", 0)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn dml_cte_returning_completes_a_wildcard_consumer() {
+        // The exposed outputs are positionally complete (named RETURNING
+        // items), so an outer `SELECT *` over the CTE expands; a written
+        // `RETURNING *` stays conservative — the expansion flag isn't
+        // carried, so the outputs mark incomplete and the outer reference
+        // dangles under the existing suppression diagnostic.
+        assert_column_ops(
+            "WITH c AS (INSERT INTO t1 (a, b) VALUES (1, 2) RETURNING a, b) \
+             SELECT * FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t1", "a"), read("t1", "b")],
+                writes: vec![write("t1", "a"), write("t1", "b")],
+                lineage: vec![
+                    passthrough(col("t1", "a"), out("a", 0)),
+                    passthrough(col("t1", "b"), out("b", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+        assert_column_ops(
+            "WITH c AS (INSERT INTO t1 (a) VALUES (1) RETURNING *) \
+             SELECT a FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![unresolved("a")],
+                writes: vec![write("t1", "a")],
+                lineage: vec![passthrough(unresolved("a"), out("a", 0))],
+                diagnostics: vec![diag(ColumnLevelDiagnosticKind::WildcardSuppressed)],
             },
         );
     }

--- a/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
+++ b/sql-insight/tests/column_operation_extractor/cte_and_dml.rs
@@ -155,6 +155,45 @@ mod with_in_dml {
     }
 
     #[test]
+    fn dml_cte_referenced_twice_traces_per_reference() {
+        // PostgreSQL runs a data-modifying CTE once however often it is
+        // referenced; each reference still traces its own output position
+        // (like a plain CTE's double reference).
+        assert_column_ops(
+            "WITH c AS (INSERT INTO t1 (a) VALUES (1) RETURNING a) \
+             SELECT c1.a, c2.a FROM c AS c1, c AS c2",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t1", "a")],
+                writes: vec![write("t1", "a")],
+                lineage: vec![
+                    passthrough(col("t1", "a"), out("a", 0)),
+                    passthrough(col("t1", "a"), out("a", 1)),
+                ],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn anonymous_returning_item_keeps_its_slot_for_a_star_consumer() {
+        // `RETURNING a + 1` has no name — it can't be referenced by name,
+        // but it holds its position, so the outer star's slot traces to it
+        // positionally (a nameless output target).
+        assert_column_ops(
+            "WITH c AS (INSERT INTO t1 (a) VALUES (1) RETURNING a + 1) \
+             SELECT * FROM c",
+            ColumnOperation {
+                statement_kind: StatementKind::Select,
+                reads: vec![read("t1", "a")],
+                writes: vec![write("t1", "a")],
+                lineage: vec![transformation(col("t1", "a"), out_anon(0))],
+                diagnostics: vec![],
+            },
+        );
+    }
+
+    #[test]
     fn with_multiple_ctes_chained_into_insert() {
         // Two CTEs where `b` references `a`. INSERT then pulls
         // from `b`. Composition walks back through both layers


### PR DESCRIPTION
## Summary

`WITH c AS (INSERT INTO t1 (a) VALUES (1) RETURNING a) SELECT a FROM c` left the outer `a` dangling `Unresolved`: a DML query body bound with an empty scope, so the CTE exposed no columns to its consumer — though PostgreSQL defines a data-modifying CTE's output as exactly its `RETURNING` list.

The DML body's scope now carries the RETURNING projection's outputs, and the origin trace knows them as the DML root's named and positional output (traced over the DML's read input). Three things follow. The outer reference resolves through the CTE like any derived column — including a renamed item (`RETURNING a AS x`) and every DML kind (INSERT / UPDATE / DELETE / MERGE `OUTPUT`). Lineage flows end to end: `WITH c AS (INSERT INTO t1 (a) SELECT a FROM src RETURNING a) SELECT a INTO t2 FROM c` now carries `src.a → t1.a` *and* `t1.a → t2.a`. And an outer `SELECT *` over the CTE expands positionally over the named RETURNING list. Completeness stays conservative: a `RETURNING *` written in the SQL marks the outputs incomplete even when it expanded — the expansion flag isn't carried on the plan — so a positional consumer suppresses with the existing diagnostic rather than trusting a possibly-partial list.

One existing pin updated to the improved behavior: the SELECT INTO + data-modifying CTE case now resolves its outer reference and completes the `t1.a → t2.a` edge instead of dangling.

## Tests

New pins: the basic INSERT RETURNING exposure, the UPDATE body with a renamed item, the outer-star expansion over a named list, the conservative `RETURNING *` suppression, a DELETE RETURNING probe folded into the above, and — from the edge-case and patch-coverage reviews — the double-referenced CTE (each reference traces its own position), an anonymous `RETURNING a + 1` item holding its slot for a star consumer, and every DML kind on both trace paths (a named reference and a star consumer over INSERT / UPDATE / DELETE / MERGE, in both the RETURNING and OUTPUT spellings). Full workspace: 927 tests, clippy and rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



